### PR TITLE
Fix vtk hash and name

### DIFF
--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -1,5 +1,4 @@
 name: "Commit Message Check"
-
 on:
   pull_request:
     types:
@@ -11,40 +10,15 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
-  commit-message-check:
+  check-commit-message:
     runs-on: ubuntu-latest
     steps:
-      # 1. Check out the repository
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      # 2. Verify that the commit messages follow the expected pattern.
-      - name: Validate commit messages
-        run: |
-          # Determine the merge-base between the current branch and main.
-          BASE=$(git merge-base origin/main HEAD)
-          echo "Checking commits since base: $BASE"
-          # Get the commit SHAs from BASE to HEAD.
-          COMMITS=$(git log $BASE..HEAD --format="%H")
-
-          # Regular expression:
-          #   • Must start with a tag in square brackets, one of: STYLE, DOC, ENH, BUG, WIP
-          #   • Followed by one or more spaces and a component tag in square brackets (should not be empty)
-          #   • Followed by one or more spaces and then the commit title.
-          #
-          # Example valid commit title:
-          #   [ENH] [packages/vtk] Improve CMake module detection
-          regex='^\[(STYLE|DOC|ENH|BUG|WIP)\][[:space:]]+\[[^]]+\][[:space:]]+.+$'
-
-          status=0
-          for commit in $COMMITS; do
-            msg=$(git log -1 --pretty=%B $commit | head -n1)
-            echo "Commit $commit: $msg"
-            if [[ ! "$msg" =~ $regex ]]; then
-              echo "ERROR: Commit $commit does not follow the required format."
-              echo "It must start with a mandatory tag [STYLE|DOC|ENH|BUG|WIP], followed by a non-empty component tag (e.g. [packages/vtk]), then the commit title."
-              status=1
-            fi
-          done
-          exit $status
+      - name: Check Commit Message
+        uses: SystoleOS/guix-systole-check-commit-message-action@9669ce2822b007f9c2191f2ccb534b2bfa5c6e6f #v1.0.0.x
+        with:
+          token: ${{ secrets.TOKEN }}

--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Check Commit Message
         uses: SystoleOS/guix-systole-check-commit-message-action@9669ce2822b007f9c2191f2ccb534b2bfa5c6e6f #v1.0.0.x
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/guix-lint-check.yml
+++ b/.github/workflows/guix-lint-check.yml
@@ -26,4 +26,4 @@ jobs:
       # 3. Run the guix lint check
       - name: Run Guix Lint
         run: |
-          guix lint -L $GITHUB_WORKSPACE --exclude=archival vtk@slicer-9.2
+          guix lint -L $GITHUB_WORKSPACE --exclude=archival vtk-slicer@9.2

--- a/guix-systole/packages/vtk.scm
+++ b/guix-systole/packages/vtk.scm
@@ -10,10 +10,11 @@
   #:use-module ((gnu packages image-processing)
                 #:prefix imgproc:))
 
-(define-public vtk
+(define-public vtk-slicer
   (package
     (inherit imgproc:vtk)
-    (version "slicer-9.2")
+    (name "vtk-slicer")
+    (version "9.2")
     (source
      (origin
        (method url-fetch)

--- a/guix-systole/packages/vtk.scm
+++ b/guix-systole/packages/vtk.scm
@@ -21,7 +21,7 @@
                            "/Slicer/VTK/archive/refs/heads/"
                            "slicer-v9.2.20230607-1ff325c54-2.zip"))
        (sha256
-        (base32 "15f3ryx945p7d95asic9gnpz8jmais2gv1gh6vfcxm7malsl8m85"))))
+        (base32 "0vkhk2mnzjs2yf9r3gmvsz2d7p58376fcqr3b41x9jvvza27mj7a"))))
     (arguments
      (list
       #:build-type "Release"

--- a/guix-systole/packages/vtk.scm
+++ b/guix-systole/packages/vtk.scm
@@ -7,8 +7,7 @@
   #:use-module (gnu packages qt)
   #:use-module (ice-9 match)
   #:use-module (srfi srfi-1)
-  #:use-module ((gnu packages image-processing)
-                #:prefix imgproc:))
+  #:use-module (gnu packages image-processing))
 
 (define-public vtk-slicer
   (package
@@ -69,5 +68,5 @@
           "-DVTK_Group_Qt:BOOL=ON"
           "-DVTK_ENABLE_KITS:BOOL=ON")
       #:tests? #f))
-    (inputs (modify-inputs (package-inputs imgproc:vtk)
+    (inputs (modify-inputs (package-inputs vtk)
               (append python-pyqt qtbase-5)))))


### PR DESCRIPTION
The source uri for the origin was changed, but its hash wasn't, hindering building. The hash has been updated to match the new origin.

The package definition also uses the new naming convention that was decided in the follow-up meeting March 4th.