### PR TITLE
[ENH][packages/vtk] Rename vtk slicer package

### DIFF
--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Check Commit Message
         uses: SystoleOS/guix-systole-check-commit-message-action@9669ce2822b007f9c2191f2ccb534b2bfa5c6e6f #v1.0.0.x
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/guix-lint-check.yml
+++ b/.github/workflows/guix-lint-check.yml
@@ -26,4 +26,4 @@ jobs:
       # 3. Run the guix lint check
       - name: Run Guix Lint
         run: |
-          guix lint -L $GITHUB_WORKSPACE --exclude=archival vtk@slicer-9.2
+          guix lint -L $GITHUB_WORKSPACE --exclude=archival vtk-slicer@9.2

--- a/guix-systole/packages/vtk.scm
+++ b/guix-systole/packages/vtk.scm
@@ -10,10 +10,11 @@
   #:use-module ((gnu packages image-processing)
                 #:prefix imgproc:))
 
-(define-public vtk
+(define-public vtk-slicer
   (package
     (inherit imgproc:vtk)
-    (version "slicer-9.2")
+    (name "vtk-slicer")
+    (version "9.2")
     (source
      (origin
        (method url-fetch)


### PR DESCRIPTION
This commit renames `vtk` to `vtk-slicer` and changes the version convention from `slicer-X.Y` to simply `X,Y`. The rationale behind this change is to avoid possible symbol collisions with `(@ (guix packages image-processing) vtk)` and make more explicit that this is the slicer-tailored vtk