### PR TITLE
[ENH][packages/libarchive] Add libarchive package

### DIFF
--- a/.github/workflows/guix-lint-check.yml
+++ b/.github/workflows/guix-lint-check.yml
@@ -28,4 +28,8 @@ jobs:
       # 3. Run the guix lint check
       - name: Run Guix Lint
         run: |
-          guix lint -L $GITHUB_WORKSPACE --exclude=archival vtk-slicer@9.2 itk-slicer@5.4.0 ctk@0.1
+          guix lint -L $GITHUB_WORKSPACE --exclude=archival \
+          vtk-slicer@9.2 \
+          itk-slicer@5.4.0 \
+          ctk@0.1 \
+          libarchive-slicer@3.6.1

--- a/guix-systole/packages/libarchive.scm
+++ b/guix-systole/packages/libarchive.scm
@@ -1,0 +1,51 @@
+(define-module (guix-systole packages libarchive)
+  #:use-module (guix build-system cmake)
+  #:use-module (guix download)
+  #:use-module (guix packages)
+  #:use-module ((guix licenses)
+                #:prefix license:))
+
+(define-public libarchive-slicer
+  (package
+    (name "libarchive-slicer")
+    (version "3.6.1")
+    (source
+     (origin
+       (method url-fetch)
+       (uri
+        "https://github.com/Slicer/libarchive/archive/14ec55f065e31fbbca23d3d96d43e07f21c6fb6d.tar.gz")
+       (sha256
+        (base32 "1l8a6x0dmvl1q664dzg1f3m92mhbwk8qyf92i4ab8yj720knazvv"))))
+    (build-system cmake-build-system)
+    (arguments
+     `(#:tests? #f
+       #:configure-flags (list "-DCMAKE_C_COMPILER:FILEPATH=gcc"
+                               "-DBUILD_SHARED_LIBS:BOOL=ON"
+                               "-DBUILD_TESTING:BOOL=OFF"
+                               "-DENABLE_ACL:BOOL=OFF"
+                               "-DENABLE_BZip2:BOOL=OFF"
+                               "-DENABLE_CAT:BOOL=OFF"
+                               "-DENABLE_CNG:BOOL=OFF"
+                               "-DENABLE_CPIO:BOOL=OFF"
+                               "-DENABLE_EXPAT:BOOL=OFF"
+                               "-DENABLE_ICONV:BOOL=OFF"
+                               "-DENABLE_LIBB2:BOOL=OFF"
+                               "-DENABLE_LibGCC:BOOL=OFF"
+                               "-DENABLE_LIBXML2:BOOL=OFF"
+                               "-DENABLE_LZ4:BOOL=OFF"
+                               "-DENABLE_LZMA:BOOL=OFF"
+                               "-DENABLE_LZO:BOOL=OFF"
+                               "-DENABLE_MBEDTLS:BOOL=OFF"
+                               "-DENABLE_NETTLE:BOOL=OFF"
+                               "-DENABLE_OPENSSL:BOOL=OFF"
+                               "-DENABLE_PCREPOSIX:BOOL=OFF"
+                               "-DENABLE_TAR:BOOL=OFF"
+                               "-DENABLE_TEST:BOOL=OFF"
+                               "-DENABLE_XATTR:BOOL=OFF"
+                               "-DENABLE_ZSTD:BOOL=OFF"
+                               "-DARCHIVE_CRYPTO_MD5_LIBSYSTEM:BOOL=OFF")))
+    (home-page "https://libarchive.org/")
+    (synopsis "Multi-format archive and compression library.")
+    (description
+     "Libarchive provides a flexible interface for reading and writing archives in various formats such as tar and cpio.  Libarchive also supports reading and writing archives compressed using various compression filters such as gzip and bzip2. The library is inherently stream-oriented; readers serially iterate through the archive, writers serially add things to the archive. In particular, note that there is currently no built-in support for random access nor for in-place modification.  This package provides the `bsdcat', `bsdcpio' and `bsdtar' commands.")
+    (license license:bsd-2)))


### PR DESCRIPTION
Slicer's libarchive is added instead of using Guix' already packaged libarchive to better support Slicer's requirements. Otherwise, patches and fixes must be made to Guix' libarchive package.