### PR TITLE
Ctk flags

### DIFF
--- a/guix-systole/packages/itk.scm
+++ b/guix-systole/packages/itk.scm
@@ -8,6 +8,7 @@
   #:use-module (gnu packages maths)
   #:use-module (gnu packages mpi)
   #:use-module (gnu packages pdf)
+  #:use-module (gnu packages qt)
   #:use-module (gnu packages serialization)
   #:use-module (gnu packages xiph)
   #:use-module (guix build-system cmake)
@@ -106,7 +107,8 @@
                       mpich
                       netcdf
                       proj
-                      vtk
+                      qtbase-5
+                      vtk-slicer
 
                       ;; GrowCut
                       itk-growcut


### PR DESCRIPTION
Here is the branch that i have been trying to fix the CTK widgets on. 
- I have only worked in the guix-systole/patckages/ctk.scm file
- The changes i have made to VTK is only on my local machine.
- 
ITs primarily the VTK-visualization-Widgets and / or ITK-core inside the ctk file that needs GuiSupportQT, but the problem is that GuiSupportQT is not being downloaded in VTK. We have tried to add flags to the VTK file in order to fix this as well as trying out a few patches but it hasn't worked. 

Here are the flags that i added to VTK.scm

- I added this one as well however it was already present in the VTK file:
```
"-DVTK_MODULE_ENABLE_VTK_GUISupportQt:STRING=YES"
```
- I have tried to add these flags right here
```
            "-DVTK_MODULE_ENABLE_VTK_ViewsContext2D:STRING=YES"
            "-DVTK_MODULE_ENABLE_VTK_ChartsCore:STRING=YES"
            "-DVTK_MODULE_ENABLE_VTK_RenderingContext2D:STRING=YES"
            "-DVTK_MODULE_ENABLE_VTK_RenderingContextOpenGL2:STRING=YES"
            "-DVTK_GROUP_ENABLE_Qt:STRING=YES"
            "-DVTK_MODULE_ENABLE_VTK_GUISupportQtOpenGL:STRING=YES # OpenGL2 rendering backend"
```
None of them work and i get this error:

-- [ITK] Skipping nonexistent library directory or not set variable [ITK_LIBRARY_DIRS]
-- [VTK] Skipping nonexistent include directory or not set variable [VTK_INCLUDE_DIRS]
-- [VTK] Skipping nonexistent library directory or not set variable [VTK_LIBRARY_DIRS]
-- CTKCore: BFD support disabled
-- Could NOT find freetype (missing: freetype_DIR)
-- Could NOT find freetype (missing: freetype_DIR)
CMake Warning at Libs/Visualization/VTK/Widgets/CMakeLists.txt:21 (find_package):
  Found package configuration file:

    /gnu/store/8dmwiwql9q0cgv5bx8prkc9h3fidkgki-vtk-9.3.0/lib/cmake/vtk-9.3/vtk-config.cmake

  but it set VTK_FOUND to FALSE so package "VTK" is considered to be NOT
  FOUND.  Reason given by package:

  Could not find the VTK package with the following required components:
  GUISupportQt.
  
I have done the normal process of looking around on the web for GuiSupportQT, gone through the flags presents in Slicers's CTK superbuild, used zcat to look on the logs as well as using live grep for GuiSupportQT inside commontk (CTK) and Slicers source code directories. 

We are using VTK 9 as well. 