### PR TITLE
[BUG[packages/slicer] Enable QT loadable modules

### DIFF
--- a/guix-systole/packages/slicer.scm
+++ b/guix-systole/packages/slicer.scm
@@ -89,7 +89,7 @@
                           "-DSlicer_BUILD_CLI_SUPPORT:BOOL=ON"
 
                           ;; QT
-                          "-DSlicer_BUILD_QTLOADABLEMODULES:BOOL=OFF"
+                          "-DSlicer_BUILD_QTLOADABLEMODULES:BOOL=ON" ;; Required to use Slicer modules
                           "-DSlicer_BUILD_QTSCRIPTEDMODULES:BOOL=OFF"
                           "-DSlicer_BUILD_QT_DESIGNER_PLUGINS:BOOL=OFF" ;Turn ON?
                           "-DSlicer_USE_QtTesting:BOOL=OFF"


### PR DESCRIPTION
This patch fixes an issue where modules would not build.

![image](https://github.com/user-attachments/assets/872e6abd-8fab-4522-ba77-a126f8c5af41)
