### PR TITLE
[ENH][packages/slicer] Generate xdg .desktop file to launch 3D Slicer

### DIFF
--- a/guix-systole/packages/slicer.scm
+++ b/guix-systole/packages/slicer.scm
@@ -164,7 +164,24 @@
                                (string-append (string-append (assoc-ref
                                                               outputs "out")
                                                              "/bin/Slicer")))
-                      #t)))))
+                      #t))
+                  (add-after 'install 'desktop-entry
+                    (lambda* (#:key outputs #:allow-other-keys)
+                      (let* ((out (assoc-ref outputs "out"))
+                             (apps-dir (string-append out
+                                                      "/share/applications"))
+                             (desktop (string-append apps-dir
+                                                     "/slicer.desktop")))
+                        (mkdir-p apps-dir)
+                        (make-desktop-entry-file desktop
+                         #:name "3dslicer"
+                         #:comment
+                         "A free, open source and multi-platform software package widely used for medical, biomedical, and related imaging research"
+                         ;; #:exec (string-append out "/bin/Slicer")
+                         #:exec (string-append out "/Slicer")
+                         #:categories '("Graphics" "MedicalSoftware" "Science")
+                         #:startup-notify #f
+                         #:terminal #f)) #t)))))
     (inputs (list libxt
                   eigen
                   expat

--- a/guix-systole/packages/slicer.scm
+++ b/guix-systole/packages/slicer.scm
@@ -179,7 +179,7 @@
                          "A free, open source and multi-platform software package widely used for medical, biomedical, and related imaging research"
                          ;; #:exec (string-append out "/bin/Slicer")
                          #:exec (string-append out "/Slicer")
-                         #:categories '("Graphics" "MedicalSoftware" "Science")
+                         #:categories '("Graphics" "Medical" "Science")
                          #:startup-notify #f
                          #:terminal #f)) #t)))))
     (inputs (list libxt


### PR DESCRIPTION
This PR adds a generated .desktop file in Slicer's store package, so that the application can easily be launched with any xdg-compliant launcher.