### PR TITLE
[ENH][packages/slicer] Introduce external packages

### DIFF
--- a/guix-systole/packages/patches/0016-ENH-packages-slicer-Add-External-Modules-directory.patch
+++ b/guix-systole/packages/patches/0016-ENH-packages-slicer-Add-External-Modules-directory.patch
@@ -1,0 +1,28 @@
+diff --git a/Modules/CMakeLists.txt b/Modules/CMakeLists.txt
+index 3f6fa9eab4..a29305d328 100644
+--- a/Modules/CMakeLists.txt
++++ b/Modules/CMakeLists.txt
+@@ -12,3 +12,6 @@ endif()
+ if(Slicer_BUILD_CLI_SUPPORT AND Slicer_BUILD_CLI)
+   add_subdirectory(CLI)
+ endif()
++
++# Build external modules
++add_subdirectory(External)
+diff --git a/Modules/External/CMakeLists.txt b/Modules/External/CMakeLists.txt
+new file mode 100644
+index 0000000000..fde9267043
+--- /dev/null
++++ b/Modules/External/CMakeLists.txt
+@@ -0,0 +1,11 @@
++## External dependencies can be added to this directory. Slicer will
++## automatically build them.
++
++file(GLOB children RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} */)
++
++foreach(child ${children})
++    if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${child}" AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${child}/CMakeLists.txt")
++      add_subdirectory(${child})
++    endif()
++endforeach()
++

--- a/guix-systole/packages/patches/0017-ENH-packages-slicer-Include-macros-to-Plots-module.patch
+++ b/guix-systole/packages/patches/0017-ENH-packages-slicer-Include-macros-to-Plots-module.patch
@@ -1,0 +1,25 @@
+diff --git a/Modules/Loadable/CMakeLists.txt b/Modules/Loadable/CMakeLists.txt
+index 606011bac6..745232e19b 100644
+--- a/Modules/Loadable/CMakeLists.txt
++++ b/Modules/Loadable/CMakeLists.txt
+@@ -18,7 +18,7 @@ set(qtmodules
+   Transforms
+   Data
+   Models
+-  Plots
++  #Plots
+   Segmentations
+   Sequences
+   SlicerWelcome
+diff --git a/Modules/Loadable/Plots/CMakeLists.txt b/Modules/Loadable/Plots/CMakeLists.txt
+index 4685399f1f..4a8c56dee6 100644
+--- a/Modules/Loadable/Plots/CMakeLists.txt
++++ b/Modules/Loadable/Plots/CMakeLists.txt
+@@ -2,6 +2,7 @@
+ #-----------------------------------------------------------------------------
+ set(MODULE_NAME Plots)
+ 
++include(${Slicer_CMAKE_DIR}/SlicerMacroBuildLoadableModule.cmake)
+ string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
+ 
+ #-----------------------------------------------------------------------------


### PR DESCRIPTION
To minimise Slicer's footprint, packages should be installed separately. This is currently not implemented, and as a temporary solution packages are instead symlinked to Slicer's source tree. This patch uses Plots as an example.