### PR TITLE
Define guix-systole as a Guix channel

### DIFF
--- a/.guix-channel
+++ b/.guix-channel
@@ -1,0 +1,25 @@
+(channel
+  (version 0)
+  (dependencies (channel
+                  (name nonguix)
+                  (url "https://gitlab.com/nonguix/nonguix")
+                  (branch "master")
+                  (commit "6c497a883d8d517987071f91a8423c4a59d6f6ff")
+                  ;; Enable signature verification
+                  (introduction
+                   (channel-introduction (version 0)
+                                         (commit
+                                          "897c1a470da759236cc11798f4e0a5f7d4d59fbc")
+                                         (signer
+                                          "2A39 3FFF 68F4 EF7A 3D29  12AF 6F51 20A0 22FB B2D5"))))
+                (channel
+                  (name guix)
+                  (url "https://git.savannah.gnu.org/git/guix.git")
+                  (branch "master")
+                  (commit "475173e4f25ad6437ee770b83e741d759f5ce380")
+                  (introduction
+                   (channel-introduction (version 0)
+                                         (commit
+                                          "9edb3f66fd807b096b48283debdcddccfea34bad")
+                                         (signer
+                                          "BBB0 2DDF 2CEA F6A8 0D1D  E643 A2A0 6DF2 A33A 54FA"))))))

--- a/.guix-channel
+++ b/.guix-channel
@@ -1,18 +1,6 @@
 (channel
   (version 0)
   (dependencies (channel
-                  (name nonguix)
-                  (url "https://gitlab.com/nonguix/nonguix")
-                  (branch "master")
-                  (commit "6c497a883d8d517987071f91a8423c4a59d6f6ff")
-                  ;; Enable signature verification
-                  (introduction
-                   (channel-introduction (version 0)
-                                         (commit
-                                          "897c1a470da759236cc11798f4e0a5f7d4d59fbc")
-                                         (signer
-                                          "2A39 3FFF 68F4 EF7A 3D29  12AF 6F51 20A0 22FB B2D5"))))
-                (channel
                   (name guix)
                   (url "https://git.savannah.gnu.org/git/guix.git")
                   (branch "master")

--- a/guix-systole/packages/qrestapi.scm
+++ b/guix-systole/packages/qrestapi.scm
@@ -7,7 +7,7 @@
   #:use-module (guix build-system cmake)
   #:use-module ((guix licenses)
                 #:prefix license:)
-  ; #:use-module (guix-systole packages)
+  #:use-module (guix-systole packages)
   )
 
 (define-public qrestapi

--- a/guix-systole/packages/qrestapi.scm
+++ b/guix-systole/packages/qrestapi.scm
@@ -1,6 +1,7 @@
 (define-module (guix-systole packages qrestapi)
   #:use-module (gnu packages qt)
   #:use-module (gnu packages)
+  #:use-module (guix gexp)
   #:use-module (guix packages)
   #:use-module (guix download)
   #:use-module (guix build-system cmake)

--- a/guix-systole/packages/qrestapi.scm
+++ b/guix-systole/packages/qrestapi.scm
@@ -6,7 +6,8 @@
   #:use-module (guix build-system cmake)
   #:use-module ((guix licenses)
                 #:prefix license:)
-  #:use-module (guix-systole packages))
+  ; #:use-module (guix-systole packages)
+  )
 
 (define-public qrestapi
   (package

--- a/guix-systole/packages/slicer.scm
+++ b/guix-systole/packages/slicer.scm
@@ -40,7 +40,8 @@
   #:use-module (guix-systole packages qrestapi)
   #:use-module (guix-systole packages teem)
   #:use-module (guix-systole packages vtk)
-  #:use-module (guix-systole packages))
+  ; #:use-module (guix-systole packages)
+  )
 
 (define-public slicer-5.8
   (package

--- a/guix-systole/packages/slicer.scm
+++ b/guix-systole/packages/slicer.scm
@@ -40,7 +40,7 @@
   #:use-module (guix-systole packages qrestapi)
   #:use-module (guix-systole packages teem)
   #:use-module (guix-systole packages vtk)
-  ; #:use-module (guix-systole packages)
+  #:use-module (guix-systole packages)
   )
 
 (define-public slicer-5.8
@@ -55,7 +55,7 @@
        (sha256
         (base32 "05rz797ddci3a2m8297zyzv2g2hp6bd6djmwa1n0gbsla8b175bx"))
        (patches (search-patches
-                "0001-COMP-Add-vtk-CommonSystem-component-as-requirement.patch"
+                 "0001-COMP-Add-vtk-CommonSystem-component-as-requirement.patch"
                  "0002-COMP-Find-Eigen-required.patch"
                  "0003-COMP-Adapt-to-new-qRestAPI-cmake.patch"
                  "0004-COMP-Hard-code-path-to-teem-library.patch"


### PR DESCRIPTION
This PR configures the `guix-systole` repository to work as a Guix channel, that users can subscribe to and pull from.

This configuration also ensures reproducibility in the future, by declaring the Guix and Nonguix channels as dependencies, both pinned to a specific commit. This should mitigate issues like https://github.com/SystoleOS/guix-systole/issues/49 from happening because of updates to other channels that we depend on.