### PR TITLE
[COMP][packages] Pin vtk and netcdf's hdf5 to v1.10

### DIFF
--- a/guix-systole/packages/ctk.scm
+++ b/guix-systole/packages/ctk.scm
@@ -21,6 +21,7 @@
                 #:prefix license:)
   #:use-module (guix packages)
   #:use-module (guix-systole packages itk)
+  #:use-module (guix-systole packages maths)
   #:use-module (guix-systole packages vtk))
 
 ;; --------------------------- CTK ---------------------------
@@ -92,7 +93,7 @@
            python
            glew
            libtheora
-           netcdf
+           netcdf-slicer
            proj        ; LibPROJ
            jsoncpp
            libxml2

--- a/guix-systole/packages/itk.scm
+++ b/guix-systole/packages/itk.scm
@@ -18,6 +18,7 @@
   #:use-module ((guix licenses)
                 #:prefix license:)
   #:use-module (guix packages)
+  #:use-module (guix-systole packages maths)
   #:use-module (guix-systole packages vtk))
 
 (define-public itk-slicer
@@ -109,7 +110,7 @@
                       libxml++
                       lz4
                       mpich
-                      netcdf
+                      netcdf-slicer
                       proj
                       qtbase-5
                       vtk-slicer

--- a/guix-systole/packages/maths.scm
+++ b/guix-systole/packages/maths.scm
@@ -1,0 +1,12 @@
+(define-module (guix-systole packages maths)
+  #:use-module (gnu packages maths)
+  #:use-module (guix packages))
+
+;; As of 26th of May 2025, Netcdf in the GNU Savannah project uses HDF5 version 
+;; 1.14
+(define-public netcdf-slicer
+  (package
+    (inherit netcdf)
+    (name "netcdf-slicer")
+    (inputs (modify-inputs (package-inputs netcdf)
+            (replace "hdf5" hdf5-1.10)))))

--- a/guix-systole/packages/slicer.scm
+++ b/guix-systole/packages/slicer.scm
@@ -36,6 +36,7 @@
   #:use-module (guix-systole packages ctk)
   #:use-module (guix-systole packages itk)
   #:use-module (guix-systole packages libarchive)
+  #:use-module (guix-systole packages maths)
   #:use-module (guix-systole packages qrestapi)
   #:use-module (guix-systole packages teem)
   #:use-module (guix-systole packages vtk)
@@ -218,7 +219,7 @@
                   libxml++
                   lz4
                   mpich
-                  netcdf
+                  netcdf-slicer
                   proj
 
                   ;; Other Slicer modules
@@ -289,7 +290,7 @@ visualization and medical image computing. It provides capabilities for:
              lz4
              jsoncpp
              mpich
-             netcdf
+             netcdf-slicer
              proj
              qtbase-5
              tbb))

--- a/guix-systole/packages/vtk.scm
+++ b/guix-systole/packages/vtk.scm
@@ -92,6 +92,7 @@
                           "-DVTK_Group_Qt:BOOL=ON"
                           "-DVTK_ENABLE_KITS:BOOL=ON")))
     (inputs (modify-inputs (package-inputs imgproc:vtk)
+            (replace "hdf5" hdf5-1.10)
               (append python-pyqt qtbase-5 tbb openmpi)))))
 
 (define-public vtkaddon

--- a/guix-systole/packages/vtk.scm
+++ b/guix-systole/packages/vtk.scm
@@ -27,7 +27,8 @@
   #:use-module (gnu packages pdf)
   #:use-module (gnu packages serialization)
   #:use-module (gnu packages tbb)
-  #:use-module (gnu packages xiph))
+  #:use-module (gnu packages xiph)
+  #:use-module (guix-systole packages maths))
 
 (define-public vtk-slicer
   (package
@@ -93,6 +94,7 @@
                           "-DVTK_ENABLE_KITS:BOOL=ON")))
     (inputs (modify-inputs (package-inputs imgproc:vtk)
             (replace "hdf5" hdf5-1.10)
+            (replace "netcdf" netcdf-slicer)
               (append python-pyqt qtbase-5 tbb openmpi)))))
 
 (define-public vtkaddon
@@ -134,7 +136,7 @@
                   libxml++
                   lz4
                   mpich
-                  netcdf
+                  netcdf-slicer
                   proj
                   qtbase-5
                   tbb))


### PR DESCRIPTION
Building Slicer, especially with guix shell to create a clean environment, causes `vtk-slicer` to panic and complains that hdf5's version is 1.14. This PR is basically a continuation of #50 and does the same fixes to VTK like 8e73b6baafd7a4600280c372c91dde882388d5e4. Additionally, `netcdf` uses hdf5 which causes the Guix build system to also complain about version 1.14. The package variation `netcdf-slicer` has been created in maths.scm to patch `netcdf`.