### PR TITLE
[BUG][packages] Disable vxl test and alter QtWebkit supported platform

### DIFF
--- a/guix-systole/packages/itk.scm
+++ b/guix-systole/packages/itk.scm
@@ -115,6 +115,7 @@
 
     (inputs (modify-inputs (package-inputs insight-toolkit)
                            (replace "hdf5" hdf5-1.10)
+			   (replace "vxl" vxl-1-slicer)
               (append ;vtk
                       double-conversion
                       freetype
@@ -269,3 +270,13 @@
     (synopsis "An ITK module to read DICOM spatial transforms.")
     (description "An ITK module to read DICOM spatial transforms.")
     (license license:asl2.0)))
+
+(define vxl-1-slicer
+  (package
+    (inherit vxl-1)
+    (name "vxl-1-slicer")
+    (version "1.18.0-slicer")
+    (arguments
+      `(#:tests? #f
+	#:configure-flags (list "-DBUILD_TESTING:BOOL=OFF")
+	))))

--- a/guix-systole/packages/qt.scm
+++ b/guix-systole/packages/qt.scm
@@ -1,0 +1,17 @@
+(define-module (guix-systole packages qt)
+	       #:use-module (guix packages)
+	       #:use-module (gnu packages qt))
+
+(define-public qtwebkit-slicer
+	       (package
+		 (inherit qtwebkit)
+		 (name "qtwebkit-slicer")
+		 (supported-systems (list "x86_64-linux" "aarch64-linux"))))
+
+(define-public python-pyqt-slicer
+	       (package
+		 (inherit python-pyqt)
+		 (name "python-pyqt-slicer")
+		    (inputs (modify-inputs (package-inputs python-pyqt)
+					   (replace "qtwebkit" qtwebkit-slicer)))
+		 (supported-systems (list "x86_64-linux" "aarch64-linux"))))

--- a/guix-systole/packages/vtk.scm
+++ b/guix-systole/packages/vtk.scm
@@ -45,7 +45,8 @@
   #:use-module (gnu packages serialization)
   #:use-module (gnu packages tbb)
   #:use-module (gnu packages xiph)
-  #:use-module (guix-systole packages maths))
+  #:use-module (guix-systole packages maths)
+  #:use-module (guix-systole packages qt))
 
 (define-public vtk-slicer
   (package
@@ -113,7 +114,7 @@
     (inputs (modify-inputs (package-inputs imgproc:vtk)
             (replace "hdf5" hdf5-1.10)
             (replace "netcdf" netcdf-slicer)
-              (append python-pyqt qtbase-5 tbb openmpi)))))
+              (append python-pyqt-slicer qtbase-5 tbb openmpi)))))
 
 (define-public vtkaddon
   (package


### PR DESCRIPTION
- For some reason, building vxl on arm will lead to failed test. Test is therefore disabled.
- Qt5's Webkit does not support ARM64. To forcefully add support, a new package variation is created and explicitly support SystoleOS currently supported platforms.

closes #59