### PR TITLE
Symlink OpenIGTLink libs and append to LD_LIBRARY_PATH

### DIFF
--- a/guix-systole/packages/openigtlink.scm
+++ b/guix-systole/packages/openigtlink.scm
@@ -131,7 +131,22 @@ both industrial and academic developers.")
                             "/lib/igtl/cmake/igtl-3.1")
              (string-append "-DOpenIGTLinkIO_DIR:PATH="
                             #$(this-package-input "openigtlinkio")
-                            "/lib/cmake/igtlio"))))
+                            "/lib/cmake/igtlio"))
+                            
+         #:phases
+           #~(modify-phases %standard-phases
+            (add-after 'install 'symlink-so-files
+               (lambda* (#:key outputs #:allow-other-keys)
+                  (let* ((out (assoc-ref outputs "out"))
+                        (lib-dir (string-append out "/lib"))
+                        (modules-dir (string-append lib-dir "/Slicer-5.8/SlicerModules")))
+                     (mkdir-p modules-dir)
+                     (for-each
+                     (lambda (file)
+                        (let ((target (string-append modules-dir "/" (basename file))))
+                           (symlink file target)))
+                     (find-files lib-dir "\\.so$"))))))
+                            ))
    (inputs
     (list slicer-5.8
           mesa

--- a/guix-systole/packages/patches/slicer/0012-ENH-AppLauncher-add-SlicerModules-libdir.patch
+++ b/guix-systole/packages/patches/slicer/0012-ENH-AppLauncher-add-SlicerModules-libdir.patch
@@ -1,0 +1,35 @@
+From 439371cab1c7d9cdf58437b39eb3b981c7e54e0f Mon Sep 17 00:00:00 2001
+From: Khai Duong <duongkhai@gmail.com>
+Date: Sun, 1 Jun 2025 14:58:25 +0200
+Subject: [PATCH] ENH Add SlicerModules lib to AppLauncher
+
+---
+ CMake/SlicerBlockCTKAppLauncherSettings.cmake | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/CMake/SlicerBlockCTKAppLauncherSettings.cmake b/CMake/SlicerBlockCTKAppLauncherSettings.cmake
+index e5d0cce6a2..df235b6b0a 100644
+--- a/CMake/SlicerBlockCTKAppLauncherSettings.cmake
++++ b/CMake/SlicerBlockCTKAppLauncherSettings.cmake
+@@ -97,6 +97,10 @@ if(Slicer_BUILD_QTLOADABLEMODULES)
+     )
+ endif()
+ 
++list(APPEND SLICER_LIBRARY_PATHS_BUILD
++    <APPLAUNCHER_SETTINGS_DIR>/SlicerModules/<CMAKE_CFG_INTDIR>
++)
++
+ # External projects - library paths
+ foreach(varname IN LISTS Slicer_EP_LABEL_LIBRARY_PATHS_LAUNCHER_BUILD)
+   list(APPEND SLICER_LIBRARY_PATHS_BUILD ${${varname}})
+@@ -237,6 +241,7 @@ set(SLICER_LIBRARY_PATHS_INSTALLED
+   <APPLAUNCHER_SETTINGS_DIR>/../${Slicer_LIB_DIR}
+   <APPLAUNCHER_SETTINGS_DIR>/../${Slicer_CLIMODULES_LIB_DIR}
+   <APPLAUNCHER_SETTINGS_DIR>/../${Slicer_QTLOADABLEMODULES_LIB_DIR}
++  <APPLAUNCHER_SETTINGS_DIR>/../${Slicer_LIB_DIR}/SlicerModules
+   )
+ 
+ # The following lines allow Slicer to load a CLI module extension that depends
+-- 
+2.49.0
+

--- a/guix-systole/packages/slicer.scm
+++ b/guix-systole/packages/slicer.scm
@@ -83,6 +83,7 @@
                  "0009-COMP-Fix-path-for-SlicerConfig.cmake-and-SlicerConfi.patch"
                  "0010-ENH-Fix-installation-of-development-files.patch"
                  "0011-ENH-Add-installation-of-Slicer-base-development-file.patch"
+                 "0012-ENH-AppLauncher-add-SlicerModules-libdir.patch"
                  ))))
     (build-system cmake-build-system)
     (arguments


### PR DESCRIPTION
This PR moved OpenIGTLink's libraries in its Store's /lib to /lib/Slicer-5.8/SlicerModules, so the user can launch Slicer as following:
```
Slicer --additional-module-path /path/to/lib/Slicer-5.8/SlicerModules
```

Furthermore, the above command requires extending the LD_LIBRARY_PATH environment variable as such:
```
LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/path/to/SlicerModules" Slicer --additional-module-path /path/to/lib/Slicer-5.8/SlicerModules
```
The patch removes the need to extend this variable.