### PR TITLE
[COMP][packages] Remove qtwebengine dependency

### DIFF
--- a/guix-systole/packages/openigtlink.scm
+++ b/guix-systole/packages/openigtlink.scm
@@ -157,7 +157,7 @@ both industrial and academic developers.")
           qtdeclarative-5
           qtsvg-5
           qtx11extras
-          qtwebengine-5
+          ;; qtwebengine-5
           qtwebchannel-5
           qttools-5
           ;;VTK
@@ -233,7 +233,7 @@ both industrial and academic developers.")
          qtdeclarative-5
          qtsvg-5
          qtx11extras
-         qtwebengine-5
+         ;; qtwebengine-5
          qtwebchannel-5
          qttools-5
          ;;VTK

--- a/guix-systole/packages/slicer.scm
+++ b/guix-systole/packages/slicer.scm
@@ -230,7 +230,7 @@ exec ~a --additional-module-path \"$HOME/.guix-profile/lib/Slicer-5.8/SlicerModu
            qtdeclarative-5
            qtsvg-5
            qtx11extras
-           qtwebengine-5
+           ;; qtwebengine-5
            qtwebchannel-5
            qttools-5
 


### PR DESCRIPTION
The QtWebEngine library isn't used in the project's current state. To save build time, it is temporarily disabled.

Closes #68