### PR TITLE
Use upstream python-3.12 from Guix; fix missing paren in slicer-5.8

### DIFF
--- a/systole/systole/packages/ctk.scm
+++ b/systole/systole/packages/ctk.scm
@@ -335,7 +335,7 @@ code search and API exploration.")))
 (define-public ctk-for-slicer-5.10
   (let ((base (make-ctk #:vtk-pkg vtk-slicer-9.5
                         #:itk-pkg itk-slicer-5.4.4
-                        #:python-pkg python-next
+                        #:python-pkg python-3.12
                         #:python-version "3.12"
                         #:pythonqt-pkg pythonqt-commontk-for-slicer-5.10)))
     (package

--- a/systole/systole/packages/itk.scm
+++ b/systole/systole/packages/itk.scm
@@ -39,8 +39,8 @@
                 #:prefix license:)
   #:use-module (guix packages)
   #:use-module (systole packages maths)
-  #:use-module (systole packages vtk)
-  #:use-module (systole packages python-xyz))
+  #:use-module (gnu packages python)
+  #:use-module (systole packages vtk))
 
 (define-public itk-slicer
   (package

--- a/systole/systole/packages/python-xyz.scm
+++ b/systole/systole/packages/python-xyz.scm
@@ -22,16 +22,8 @@
   #:use-module (gnu packages python)
   #:use-module (gnu packages python-xyz))
 
-;; Pinned Python 3.12 alias.  python-next drifts over time; this alias asserts
-;; the major/minor at module load so a silent upgrade to 3.13 fails loudly
-;; instead of mysteriously breaking the Slicer 5.10 PYTHONPATH (which scans
-;; lib/python3.12/site-packages).
-(define-public python-3.12
-  (let ((p python-next))
-    (unless (string-prefix? "3.12." (package-version p))
-      (error "python-next is no longer 3.12.x; update systole/packages accordingly"
-             (package-version p)))
-    p))
+;; python-3.12 is now exported by (gnu packages python) upstream.
+;; We import it from there and use it for the wrapper and rewriter below.
 
 ;; Python 3.12 wrapper that provides the 'python' binary (symlink to python3),
 ;; suitable for use as the #:python argument in pyproject-build-system.

--- a/systole/systole/packages/pythonqt.scm
+++ b/systole/systole/packages/pythonqt.scm
@@ -90,5 +90,5 @@
 
 (define-public pythonqt-commontk-for-slicer-5.10
   (make-pythonqt-commontk #:name "pythonqt-commontk-for-slicer-5.10"
-                           #:python-pkg python-next
+                           #:python-pkg python-3.12
                            #:python-version "3.12"))

--- a/systole/systole/packages/slicer.scm
+++ b/systole/systole/packages/slicer.scm
@@ -202,7 +202,7 @@ development tools, code search, and documentation generation.")
                  "0074-COMP-Fix-designer-plugin-build-dir-and-install-path-.patch"
                  "0075-COMP-Install-Slicer-VTK-hierarchy-files-and-expose-p.patch"
                  "0076-ENH-Redirect-pip_install-to-user-home-and-update-sys.patch"
-                 "0079-ENH-Add-GUIX_ENVIRONMENT-module-path-to-LD_LIBRARY_P.patch"))))
+                 "0079-ENH-Add-GUIX_ENVIRONMENT-module-path-to-LD_LIBRARY_P.patch")))))
 
     (build-system cmake-build-system)
     (arguments
@@ -1192,8 +1192,7 @@ visualization and medical image computing.")
     (license license:bsd-3)))
 
 ;; slicer-5.10 is the canonical public Slicer 5.10 package.  Python support is
-;; enabled via python-next (3.12).  VTK 9.5, ITK 5.4.4, and vtkAddon (9.5) are
-;; used.
+;; enabled via python-3.12.  VTK 9.5, ITK 5.4.4, and vtkAddon (9.5) are used.
 (define-public slicer-5.10
   (package
     (inherit %slicer-5.10)
@@ -1203,7 +1202,7 @@ visualization and medical image computing.")
        ((#:configure-flags flags)
         #~(append
            (list
-            ;; Python — Guix python-next (3.12)
+            ;; Python 3.12 (upstream package name is still "python-next")
             (string-append "-DPython3_EXECUTABLE="
                            #$(this-package-input "python-next") "/bin/python3")
             (string-append "-DPython3_INCLUDE_DIR="

--- a/systole/systole/packages/vtk.scm
+++ b/systole/systole/packages/vtk.scm
@@ -50,7 +50,6 @@
   #:use-module (gnu packages tbb)
   #:use-module (gnu packages xiph)
   #:use-module (systole packages maths)
-  #:use-module (systole packages python-xyz)
   #:use-module (systole packages))
 
 ;; Private non-Python base — used only for (inherit) in vtk-slicer (Python).


### PR DESCRIPTION
## Summary

- Drops `python-3.12` definition from `(systole packages python-xyz)` — Guix upstream now exports it directly from `(gnu packages python)`, avoiding a name conflict
- Replaces `python-next` references in `pythonqt.scm` and `ctk.scm` with `python-3.12`
- Removes `(systole packages python-xyz)` import from `vtk.scm` (uses `(gnu packages python)` already) and `itk.scm` (now imports it explicitly)
- Fixes a pre-existing missing closing paren in `%slicer-5.8`'s patch list (lost when `search-patches` was replaced with `(map (lambda (p) (slicer-patch "5.8" p)) (list ...))` — caused the entire module to fail compilation under `guix build`)

## Test plan

- [x] All modified modules load without error in `guix repl`
- [x] `guix build -L systole slicer-5.10` succeeds