### PR TITLE
Integrate SlicerROS2 + 3D Systems Touch haptic device demo

### DIFF
--- a/systole/systole/licenses.scm
+++ b/systole/systole/licenses.scm
@@ -16,7 +16,9 @@
 ;;
 
 (define-module (systole licenses)
-  #:export (slul))
+  #:export (slul
+            openhaptics-eula
+            3ds-touch-driver-eula))
 
 ;; Guix does not export the license record constructor.
 (define license (@@ (guix licenses) license))
@@ -25,3 +27,20 @@
   (license "Simple Library Usage License"
            "https://svn.code.sf.net/p/teem/code/teem/trunk/LICENSE.txt"
            "A simple permissive license for library usage."))
+
+;; 3D Systems proprietary EULA that ships with OpenHaptics 3.4 Developer
+;; Edition and the Touch device driver.  The SDK and driver are freely
+;; downloadable from 3D Systems' public S3 bucket but may only be used
+;; under the terms printed in their respective README_INSTALL files.
+;; These packages are non-free; they are provided in this channel to
+;; make the JHU sawSensablePhantom stack buildable against the 3D
+;; Systems Touch haptic device.
+(define openhaptics-eula
+  (license "OpenHaptics Developer Edition EULA"
+           "https://www.3dsystems.com/software/openhaptics-developer-license"
+           "3D Systems proprietary license for the OpenHaptics SDK."))
+
+(define 3ds-touch-driver-eula
+  (license "3D Systems Touch Device Driver EULA"
+           "https://www.3dsystems.com/haptics-devices/touch"
+           "3D Systems proprietary license for the Touch USB driver."))

--- a/systole/systole/packages/cisst.scm
+++ b/systole/systole/packages/cisst.scm
@@ -398,7 +398,23 @@ and are not needed for the Touch demo.")
                                (number->string (parallel-job-count))
                                "1"))))
           (replace 'install
-            (lambda _ (invoke "cmake" "--install" "build"))))))
+            (lambda _ (invoke "cmake" "--install" "build")))
+          ;; Install the JSON device config files from core/share/.
+          ;; These are not installed by core/components/CMakeLists.txt
+          ;; but are needed at runtime (e.g. -j <path>/sawSensablePhantomDefaultDevice.json).
+          (add-after 'install 'install-share
+            (lambda* (#:key outputs #:allow-other-keys)
+              (let ((share (string-append (assoc-ref outputs "out")
+                                         "/share/sawSensablePhantom")))
+                (for-each
+                 (lambda (f)
+                   (let ((src (string-append (getcwd) "/core/share/" f)))
+                     (when (file-exists? src)
+                       (install-file src share))))
+                 '("sawSensablePhantomDefault.json"
+                   "sawSensablePhantomDefaultDevice.json"
+                   "sawSensablePhantomLeft.json"
+                   "sawSensablePhantomRight.json"))))))))
     (inputs (list cisst cisst-netlib saw-keyboard saw-controllers
                   jsoncpp libxml2
                   qtbase-5

--- a/systole/systole/packages/cisst.scm
+++ b/systole/systole/packages/cisst.scm
@@ -160,6 +160,15 @@ drives the 3D Systems Touch.")
               "-DCISST_BUILD_EXAMPLES=OFF"
               "-DCISST_BUILD_APPLICATIONS=OFF"
               "-DCISST_HAS_JSON=ON"
+              ;; cisstNumerical defaults CISST_HAS_CISSTNETLIB to OFF
+              ;; outside catkin builds; without it cisstRobot is
+              ;; silently skipped and downstream saw* packages fail.
+              "-DCISST_HAS_CISSTNETLIB=ON"
+              ;; cisstRobot defaults to building robReflexxes, which
+              ;; ExternalProject-clones ReflexxesTypeII from GitHub.
+              ;; Disable — not used by the sawControllers/
+              ;; sawSensablePhantom code paths we need.
+              "-DCISST_ROB_HAS_REFLEXXES_TYPEII=OFF"
               ;; Use pkg-config to pick up Guix's jsoncpp instead of
               ;; the cisstJSONExternal ExternalProject_Add that would
               ;; clone jsoncpp from GitHub.
@@ -208,4 +217,116 @@ the optional @code{cisstMesh}/@code{cisstStereoVision}/
 @code{cisst3DUserInterface} libraries are all disabled — they are not
 needed for the haptic-device control path and would pull in large
 unused dependencies.")
+    (license license:bsd-3)))
+
+;;;
+;;; sawKeyboard — cisst/SAW keyboard-input component.  Pure cisst,
+;;; no ROS dependency.  Required by sawControllers and beyond.
+;;;
+
+(define-public saw-keyboard
+  (package
+    (name "saw-keyboard")
+    (version "1.4.1")
+    (source
+     (origin
+       (method git-fetch)
+       (uri (git-reference
+             (url "https://github.com/jhu-saw/sawKeyboard")
+             (commit "2c254c5cfd9acc86188a76e7b615e526a21e56ac")))
+       (file-name (git-file-name name version))
+       (sha256
+        (base32 "116j5nhgxdxyazlfsyxn710vr3s9fy95raqg1y1yb04qqzri7lq5"))))
+    (build-system cmake-build-system)
+    (arguments
+     (list
+      #:tests? #f
+      #:configure-flags
+      #~(list "-DCMAKE_BUILD_TYPE=Release"
+              (string-append "-Dcisst_DIR="
+                             #$(this-package-input "cisst")
+                             "/share/cisst-1.4/cmake"))
+      #:phases
+      #~(modify-phases %standard-phases
+          (add-before 'configure 'set-install-rpath
+            (lambda _
+              (setenv "CMAKE_INSTALL_RPATH"
+                      "$ORIGIN:$ORIGIN/../lib"))))))
+    (inputs (list cisst cisst-netlib))
+    (home-page "https://github.com/jhu-saw/sawKeyboard")
+    (synopsis "cisst/SAW keyboard-input component")
+    (description
+     "@code{sawKeyboard} is a cisst @code{mtsComponent} that turns
+terminal key presses into cisst events.  It is a build dependency of
+@code{sawControllers} and, transitively, @code{sawSensablePhantom}.")
+    (license license:bsd-3)))
+
+;;;
+;;; sawControllers (core) — cisst/SAW PID, gravity-compensation, and
+;;; teleop controllers.  Required by sawSensablePhantom.
+;;;
+
+(define-public saw-controllers
+  (package
+    (name "saw-controllers")
+    (version "2.3.0")
+    (source
+     (origin
+       (method git-fetch)
+       (uri (git-reference
+             (url "https://github.com/jhu-saw/sawControllers")
+             (commit "cc8870e20ef0954745a83cbc4eda7d167e3bda9a")))
+       (file-name (git-file-name name version))
+       (sha256
+        (base32 "0ih28k1b09hnqn4crk0ffpk6rrjxcnnld0y8xcsxyfk0vijnly3n"))))
+    (build-system cmake-build-system)
+    (arguments
+     (list
+      #:tests? #f
+      ;; Build only core/components — core/ also adds_subdirectory
+      ;; (examples) which needs Qt; we don't need those.
+      #:configure-flags
+      #~(list "-DCMAKE_BUILD_TYPE=Release"
+              (string-append "-Dcisst_DIR="
+                             #$(this-package-input "cisst")
+                             "/share/cisst-1.4/cmake")
+              (string-append "-DsawKeyboard_DIR="
+                             #$(this-package-input "saw-keyboard")
+                             "/share/sawKeyboard"))
+      #:phases
+      #~(modify-phases %standard-phases
+          (replace 'configure
+            (lambda* (#:key outputs configure-flags #:allow-other-keys)
+              (let ((source (getcwd))
+                    (out (assoc-ref outputs "out")))
+                (apply invoke "cmake"
+                       "-S" (string-append source "/core/components")
+                       "-B" "build"
+                       (string-append "-DCMAKE_INSTALL_PREFIX=" out)
+                       configure-flags))))
+          (replace 'build
+            (lambda* (#:key parallel-build? #:allow-other-keys)
+              (invoke "cmake" "--build" "build"
+                      "-j" (if parallel-build?
+                               (number->string (parallel-job-count))
+                               "1"))))
+          (replace 'install
+            (lambda _ (invoke "cmake" "--install" "build")))
+          (add-before 'configure 'set-install-rpath
+            (lambda _
+              (setenv "CMAKE_INSTALL_RPATH"
+                      "$ORIGIN:$ORIGIN/../lib"))))))
+    (inputs (list cisst cisst-netlib saw-keyboard
+                  ;; cisst's mtsCommonXML/JSON leaks libjsoncpp.so.26
+                  ;; into downstream link; RUNPATH validation needs it.
+                  jsoncpp))
+    (home-page "https://github.com/jhu-saw/sawControllers")
+    (synopsis "cisst/SAW PID and teleoperation controllers")
+    (description
+     "@code{sawControllers} bundles the cisst implementations of PID
+joint controllers, gravity compensation, and teleoperation components
+used by JHU's haptic-device stack.  This Guix package builds only the
+@code{core/components} subtree (the shared library); the example
+programs in @code{core/examples} are skipped because they pull in Qt
+and are not needed for the Touch demo.")
     (license license:bsd-3)))

--- a/systole/systole/packages/cisst.scm
+++ b/systole/systole/packages/cisst.scm
@@ -1,0 +1,124 @@
+;;
+;; Copyright @ 2026 Oslo University Hospital
+;;
+;; This file is part of SystoleOS.
+;;
+;; SystoleOS is free software: you can redistribute it and/or modify it under the
+;; terms of the GNU General Public License as published by the Free Software
+;; Foundation, either version 3 of the License, or (at your option) any later version.
+;;
+;; SystoleOS is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+;; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+;; PURPOSE. See the GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License along
+;; with SystoleOS. If not, see <https://www.gnu.org/licenses/>.
+;;
+
+;;; Commentary:
+;;;
+;;; JHU cisst (Computer Integrated Surgical Systems and Technology) —
+;;; the robotics / surgical-systems C++ framework that underlies the
+;;; entire JHU saw- stack, including sawSensablePhantom and, through
+;;; it, Laura Connolly's SlicerROS2 Touch demo.
+;;;
+;;; cisst ships a small Custom BSD-like license ("cisst license") that
+;;; is documented at http://www.cisst.org/cisst/license.txt; we map it
+;;; to @code{license:bsd-3} which closely matches its terms.
+;;;
+;;; Code:
+
+(define-module (systole packages cisst)
+  #:use-module ((guix licenses) #:prefix license:)
+  #:use-module (guix build-system cmake)
+  #:use-module (guix gexp)
+  #:use-module (guix git-download)
+  #:use-module (guix packages)
+  #:use-module (guix utils)
+  #:use-module (gnu packages commencement) ; gfortran-toolchain
+  #:use-module (gnu packages gcc)           ; gfortran
+  #:use-module (gnu packages maths)         ; lapack (unused, reference)
+  #:use-module (gnu packages python))
+
+;;;
+;;; clapack source — a separate origin so cisstNetlib's ExternalProject
+;;; pipeline does not need network access at build time.  Pinned to the
+;;; commit on jhu-cisst-external/clapack#main from which cisstNetlib
+;;; 3.2.2 expects its F2C-translated LAPACK.
+;;;
+
+(define clapack-source
+  (origin
+    (method git-fetch)
+    (uri (git-reference
+          (url "https://github.com/jhu-cisst-external/clapack")
+          (commit "93ef9f8fc85e8267a56a08a597f796c8624b9e57")))
+    (file-name "clapack-93ef9f8.tar.gz")
+    (sha256
+     (base32 "16yijw248pb545553975imhv5z7blvhisgzyg9vbyxxsdk30idra"))))
+
+;;;
+;;; cisstNetlib — JHU's F2C-translated LAPACK/BLAS wrapper library.
+;;;
+
+(define-public cisst-netlib
+  (package
+    (name "cisst-netlib")
+    (version "3.2.2")
+    (source
+     (origin
+       (method git-fetch)
+       (uri (git-reference
+             (url "https://github.com/jhu-cisst/cisstNetlib")
+             (commit "9112629f712677ef547dfca081a781c7febf911b")))
+       (file-name (git-file-name name version))
+       (sha256
+        (base32 "08gmjnaxw77bbk3mxv95flj65iz1idfz5djzm1x0w0cyyjpk3igc"))))
+    (build-system cmake-build-system)
+    (arguments
+     (list
+      #:tests? #f
+      #:configure-flags
+      #~(list "-DcisstNetlib_LANGUAGE=C"
+              "-DCMAKE_BUILD_TYPE=Release"
+              "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
+      #:phases
+      #~(modify-phases %standard-phases
+          (add-after 'unpack 'disable-clapack-download
+            (lambda _
+              ;; Strip the network GIT_REPOSITORY/GIT_TAG pair from
+              ;; ExternalProject_Add; we will populate the expected
+              ;; SOURCE_DIR path manually after 'configure (see
+              ;; 'populate-clapack below) so ExternalProject_Add's
+              ;; build step finds clapack already in place.
+              (substitute* "CMakeLists.txt"
+                (("GIT_REPOSITORY \"https://github\\.com/jhu-cisst-external/clapack\"")
+                 "DOWNLOAD_COMMAND \"\"")
+                (("GIT_TAG \"main\"")
+                 ""))))
+          (add-after 'configure 'populate-clapack
+            (lambda _
+              ;; cisstNetlib's ExternalProject_Add computes
+              ;;   ${CMAKE_BINARY_DIR}/cisstNetlibLapack/src/cisstNetlib_C
+              ;; and cisstNetlib's top-level include_directories() hard
+              ;; codes that same path.  Copy the pre-fetched clapack
+              ;; tree into it before the ExternalProject build target
+              ;; runs.
+              (let ((dst "../build/cisstNetlibLapack/src/cisstNetlib_C"))
+                (mkdir-p (dirname dst))
+                (copy-recursively #$clapack-source dst))))
+          (add-after 'unpack 'set-install-rpath
+            (lambda _
+              (setenv "CMAKE_INSTALL_RPATH"
+                      "$ORIGIN:$ORIGIN/../lib"))))))
+    (home-page "https://github.com/jhu-cisst/cisstNetlib")
+    (synopsis "JHU cisst F2C-translated LAPACK/BLAS wrapper")
+    (description
+     "@code{cisstNetlib} packages an F2C-translated LAPACK/BLAS plus
+cisst-specific numerical routines (Hanson-Haskell, Lawson-Hanson) under
+the @code{cisstNetlib_} symbol prefix.  It is the dense-linear-algebra
+backend used by @code{cisstNumerical} and, transitively, any cisst
+component that performs matrix factorisations — including the trajectory
+generation and inverse kinematics used by the sawControllers stack that
+drives the 3D Systems Touch.")
+    (license license:bsd-3)))

--- a/systole/systole/packages/cisst.scm
+++ b/systole/systole/packages/cisst.scm
@@ -40,6 +40,7 @@
   #:use-module (gnu packages maths)         ; lapack (unused, reference)
   #:use-module (gnu packages python)
   #:use-module (gnu packages pkg-config)    ; pkg-config
+  #:use-module (gnu packages qt)            ; qtbase-5, qttools
   #:use-module (gnu packages serialization) ; jsoncpp
   #:use-module (gnu packages xml)           ; libxml2
   #:use-module (gnu packages compression)   ; zlib
@@ -175,7 +176,11 @@ drives the 3D Systems Touch.")
               ;; clone jsoncpp from GitHub.
               "-DCISST_USE_PKG_CONFIG=ON"
               "-DCISST_HAS_SWIG_PYTHON=OFF"
-              "-DCISST_HAS_QT5=OFF"
+              ;; Qt5 is required by the sawSensablePhantom ROS 2
+              ;; executable (Laura Connolly's Touch demo), which
+              ;; needs cisstCommonQt/VectorQt/MultiTaskQt/ParameterTypesQt
+              ;; and cisstQt.
+              "-DCISST_HAS_QT5=ON"
               "-DCISST_HAS_IOS=OFF"
               "-DCISST_HAS_LINUX_RTAI=OFF"
               "-DCISST_HAS_LINUX_XENOMAI=OFF"
@@ -200,7 +205,12 @@ drives the 3D Systems Touch.")
               (setenv "CMAKE_INSTALL_RPATH"
                       "$ORIGIN:$ORIGIN/../lib"))))))
     (native-inputs (list pkg-config))
-    (inputs (list cisst-netlib jsoncpp libxml2 zlib))
+    (inputs (list cisst-netlib jsoncpp libxml2 zlib
+                  ;; Qt5 for the *Qt companion libraries.  cisst
+                  ;; requests Qt5Core/Xml/XmlPatterns/Widgets/Gui/
+                  ;; OpenGL — all but XmlPatterns are in qtbase-5.
+                  qtbase-5
+                  (@ (gnu packages qt) qtxmlpatterns-5)))
     (home-page "https://github.com/jhu-cisst/cisst")
     (synopsis "JHU cisst robotics / surgical-systems framework")
     (description
@@ -244,16 +254,19 @@ unused dependencies.")
       #:tests? #f
       #:configure-flags
       #~(list "-DCMAKE_BUILD_TYPE=Release"
+              "-DCMAKE_INSTALL_RPATH=$ORIGIN;$ORIGIN/../lib"
+              "-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON"
               (string-append "-Dcisst_DIR="
                              #$(this-package-input "cisst")
                              "/share/cisst-1.4/cmake"))
       #:phases
-      #~(modify-phases %standard-phases
-          (add-before 'configure 'set-install-rpath
-            (lambda _
-              (setenv "CMAKE_INSTALL_RPATH"
-                      "$ORIGIN:$ORIGIN/../lib"))))))
-    (inputs (list cisst cisst-netlib))
+      #~(modify-phases %standard-phases)))
+    (inputs (list cisst cisst-netlib
+                  ;; cisst's CMake config re-invokes find_package(Qt5*)
+                  ;; on downstream consumers because cisst is Qt-enabled.
+                  qtbase-5
+                  (@ (gnu packages qt) qtxmlpatterns-5)
+                  jsoncpp))
     (home-page "https://github.com/jhu-saw/sawKeyboard")
     (synopsis "cisst/SAW keyboard-input component")
     (description
@@ -288,6 +301,8 @@ terminal key presses into cisst events.  It is a build dependency of
       ;; (examples) which needs Qt; we don't need those.
       #:configure-flags
       #~(list "-DCMAKE_BUILD_TYPE=Release"
+              "-DCMAKE_INSTALL_RPATH=$ORIGIN;$ORIGIN/../lib"
+              "-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON"
               (string-append "-Dcisst_DIR="
                              #$(this-package-input "cisst")
                              "/share/cisst-1.4/cmake")
@@ -312,15 +327,14 @@ terminal key presses into cisst events.  It is a build dependency of
                                (number->string (parallel-job-count))
                                "1"))))
           (replace 'install
-            (lambda _ (invoke "cmake" "--install" "build")))
-          (add-before 'configure 'set-install-rpath
-            (lambda _
-              (setenv "CMAKE_INSTALL_RPATH"
-                      "$ORIGIN:$ORIGIN/../lib"))))))
+            (lambda _ (invoke "cmake" "--install" "build"))))))
     (inputs (list cisst cisst-netlib saw-keyboard
                   ;; cisst's mtsCommonXML/JSON leaks libjsoncpp.so.26
-                  ;; into downstream link; RUNPATH validation needs it.
-                  jsoncpp))
+                  ;; and libxml2 into downstream link; add both.
+                  jsoncpp libxml2
+                  ;; cisst re-invokes find_package(Qt5*) downstream.
+                  qtbase-5
+                  (@ (gnu packages qt) qtxmlpatterns-5)))
     (home-page "https://github.com/jhu-saw/sawControllers")
     (synopsis "cisst/SAW PID and teleoperation controllers")
     (description
@@ -357,6 +371,8 @@ and are not needed for the Touch demo.")
       #:tests? #f
       #:configure-flags
       #~(list "-DCMAKE_BUILD_TYPE=Release"
+              "-DCMAKE_INSTALL_RPATH=$ORIGIN;$ORIGIN/../lib"
+              "-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON"
               (string-append "-Dcisst_DIR="
                              #$(this-package-input "cisst")
                              "/share/cisst-1.4/cmake")
@@ -382,13 +398,11 @@ and are not needed for the Touch demo.")
                                (number->string (parallel-job-count))
                                "1"))))
           (replace 'install
-            (lambda _ (invoke "cmake" "--install" "build")))
-          (add-before 'configure 'set-install-rpath
-            (lambda _
-              (setenv "CMAKE_INSTALL_RPATH"
-                      "$ORIGIN:$ORIGIN/../lib"))))))
+            (lambda _ (invoke "cmake" "--install" "build"))))))
     (inputs (list cisst cisst-netlib saw-keyboard saw-controllers
-                  jsoncpp
+                  jsoncpp libxml2
+                  qtbase-5
+                  (@ (gnu packages qt) qtxmlpatterns-5)
                   ;; libHD + libPhantomIOLib42 from the proprietary
                   ;; OpenHaptics stack.  openhaptics-sdk propagates
                   ;; touch-driver automatically.

--- a/systole/systole/packages/cisst.scm
+++ b/systole/systole/packages/cisst.scm
@@ -38,7 +38,11 @@
   #:use-module (gnu packages commencement) ; gfortran-toolchain
   #:use-module (gnu packages gcc)           ; gfortran
   #:use-module (gnu packages maths)         ; lapack (unused, reference)
-  #:use-module (gnu packages python))
+  #:use-module (gnu packages python)
+  #:use-module (gnu packages pkg-config)    ; pkg-config
+  #:use-module (gnu packages serialization) ; jsoncpp
+  #:use-module (gnu packages xml)           ; libxml2
+  #:use-module (gnu packages compression))  ; zlib
 
 ;;;
 ;;; clapack source — a separate origin so cisstNetlib's ExternalProject
@@ -121,4 +125,87 @@ backend used by @code{cisstNumerical} and, transitively, any cisst
 component that performs matrix factorisations — including the trajectory
 generation and inverse kinematics used by the sawControllers stack that
 drives the 3D Systems Touch.")
+    (license license:bsd-3)))
+
+;;;
+;;; cisst — JHU's Computer Integrated Surgical Systems and Technology
+;;; C++ framework.  Minimal build profile: the 7 default libraries
+;;; (cisstCommon, cisstVector, cisstOSAbstraction, cisstNumerical,
+;;; cisstMultiTask, cisstParameterTypes, cisstRobot) as shared libs,
+;;; with JSON support on and everything else off.  Enough to build
+;;; the saw- stack and, transitively, sawSensablePhantom / ROS 2.
+;;;
+
+(define-public cisst
+  (package
+    (name "cisst")
+    (version "1.4.0")
+    (source
+     (origin
+       (method git-fetch)
+       (uri (git-reference
+             (url "https://github.com/jhu-cisst/cisst")
+             (commit "fe84bf08817dc67e0fbf782190c656fe9cc5c2df")))
+       (file-name (git-file-name name version))
+       (sha256
+        (base32 "095icl70bh8kdsq30bds2jmn70gqykmhskjshij89q8gq5d9gqm8"))))
+    (build-system cmake-build-system)
+    (arguments
+     (list
+      #:tests? #f
+      #:configure-flags
+      #~(list "-DCMAKE_BUILD_TYPE=Release"
+              "-DCISST_BUILD_SHARED_LIBS=ON"
+              "-DCISST_BUILD_TESTS=OFF"
+              "-DCISST_BUILD_EXAMPLES=OFF"
+              "-DCISST_BUILD_APPLICATIONS=OFF"
+              "-DCISST_HAS_JSON=ON"
+              ;; Use pkg-config to pick up Guix's jsoncpp instead of
+              ;; the cisstJSONExternal ExternalProject_Add that would
+              ;; clone jsoncpp from GitHub.
+              "-DCISST_USE_PKG_CONFIG=ON"
+              "-DCISST_HAS_SWIG_PYTHON=OFF"
+              "-DCISST_HAS_QT5=OFF"
+              "-DCISST_HAS_IOS=OFF"
+              "-DCISST_HAS_LINUX_RTAI=OFF"
+              "-DCISST_HAS_LINUX_XENOMAI=OFF"
+              "-DCISST_USE_SI_UNITS=ON"
+              ;; Optional libs off — only the 7 default libs.
+              "-DCISST_cisstMesh=OFF"
+              "-DCISST_cisstInteractive=OFF"
+              "-DCISST_cisstStereoVision=OFF"
+              "-DCISST_cisst3DUserInterface=OFF"
+              ;; cisstNetlib location for cisstNumerical.
+              (string-append "-DCisstNetlib_DIR="
+                             #$(this-package-input "cisst-netlib")
+                             "/share/cisstNetlib"))
+      #:phases
+      #~(modify-phases %standard-phases
+          (add-before 'configure 'set-install-rpath
+            (lambda _
+              ;; cisst installs libcisst*.so into lib/; internal
+              ;; libraries dlopen each other and must resolve via
+              ;; $ORIGIN, and cisst-netlib's config dir is used at
+              ;; configure time only (its libs are static).
+              (setenv "CMAKE_INSTALL_RPATH"
+                      "$ORIGIN:$ORIGIN/../lib"))))))
+    (native-inputs (list pkg-config))
+    (inputs (list cisst-netlib jsoncpp libxml2 zlib))
+    (home-page "https://github.com/jhu-cisst/cisst")
+    (synopsis "JHU cisst robotics / surgical-systems framework")
+    (description
+     "@code{cisst} is the Johns Hopkins Computer Integrated Surgical
+Systems and Technology framework — a C++ collection of libraries used
+as the foundation of the JHU saw- robot-integration components and,
+through them, Laura Connolly's SlicerROS2 Touch haptic-device demo.
+
+This Guix package builds the seven default shared libraries
+(@code{cisstCommon}, @code{cisstVector}, @code{cisstOSAbstraction},
+@code{cisstNumerical}, @code{cisstMultiTask}, @code{cisstParameterTypes},
+@code{cisstRobot}) with JSON support enabled; SWIG/Python bindings,
+Qt5 widgets, FLTK widgets, real-time extensions (RTAI, Xenomai), and
+the optional @code{cisstMesh}/@code{cisstStereoVision}/
+@code{cisst3DUserInterface} libraries are all disabled — they are not
+needed for the haptic-device control path and would pull in large
+unused dependencies.")
     (license license:bsd-3)))

--- a/systole/systole/packages/cisst.scm
+++ b/systole/systole/packages/cisst.scm
@@ -42,7 +42,8 @@
   #:use-module (gnu packages pkg-config)    ; pkg-config
   #:use-module (gnu packages serialization) ; jsoncpp
   #:use-module (gnu packages xml)           ; libxml2
-  #:use-module (gnu packages compression))  ; zlib
+  #:use-module (gnu packages compression)   ; zlib
+  #:use-module (systole packages openhaptics))  ; openhaptics-sdk, touch-driver
 
 ;;;
 ;;; clapack source — a separate origin so cisstNetlib's ExternalProject
@@ -329,4 +330,75 @@ used by JHU's haptic-device stack.  This Guix package builds only the
 @code{core/components} subtree (the shared library); the example
 programs in @code{core/examples} are skipped because they pull in Qt
 and are not needed for the Touch demo.")
+    (license license:bsd-3)))
+
+;;;
+;;; sawSensablePhantom (core) — cisst/SAW component that talks to
+;;; the 3D Systems Touch via OpenHaptics HD.  First consumer of
+;;; openhaptics-sdk and touch-driver from (systole packages openhaptics).
+;;;
+
+(define-public saw-sensable-phantom
+  (package
+    (name "saw-sensable-phantom")
+    (version "1.1.0")
+    (source
+     (origin
+       (method git-fetch)
+       (uri (git-reference
+             (url "https://github.com/jhu-saw/sawSensablePhantom")
+             (commit "64c8b05ec2263a93a1ebd1a2bd508c2c46d024a9")))
+       (file-name (git-file-name name version))
+       (sha256
+        (base32 "1a32y6qdsrpyvq9i2v0w5kw1xbngbi4nkm4rxvn83kaddwy4jm6b"))))
+    (build-system cmake-build-system)
+    (arguments
+     (list
+      #:tests? #f
+      #:configure-flags
+      #~(list "-DCMAKE_BUILD_TYPE=Release"
+              (string-append "-Dcisst_DIR="
+                             #$(this-package-input "cisst")
+                             "/share/cisst-1.4/cmake")
+              (string-append "-DsawControllers_DIR="
+                             #$(this-package-input "saw-controllers")
+                             "/share/sawControllers"))
+      #:phases
+      #~(modify-phases %standard-phases
+          ;; Build only core/components; core/examples requires Qt.
+          (replace 'configure
+            (lambda* (#:key outputs configure-flags #:allow-other-keys)
+              (let ((source (getcwd))
+                    (out (assoc-ref outputs "out")))
+                (apply invoke "cmake"
+                       "-S" (string-append source "/core/components")
+                       "-B" "build"
+                       (string-append "-DCMAKE_INSTALL_PREFIX=" out)
+                       configure-flags))))
+          (replace 'build
+            (lambda* (#:key parallel-build? #:allow-other-keys)
+              (invoke "cmake" "--build" "build"
+                      "-j" (if parallel-build?
+                               (number->string (parallel-job-count))
+                               "1"))))
+          (replace 'install
+            (lambda _ (invoke "cmake" "--install" "build")))
+          (add-before 'configure 'set-install-rpath
+            (lambda _
+              (setenv "CMAKE_INSTALL_RPATH"
+                      "$ORIGIN:$ORIGIN/../lib"))))))
+    (inputs (list cisst cisst-netlib saw-keyboard saw-controllers
+                  jsoncpp
+                  ;; libHD + libPhantomIOLib42 from the proprietary
+                  ;; OpenHaptics stack.  openhaptics-sdk propagates
+                  ;; touch-driver automatically.
+                  openhaptics-sdk))
+    (supported-systems '("x86_64-linux"))
+    (home-page "https://github.com/jhu-saw/sawSensablePhantom")
+    (synopsis "cisst/SAW component for the 3D Systems Touch haptic device")
+    (description
+     "@code{sawSensablePhantom} is the cisst @code{mtsComponent} that
+wraps the OpenHaptics HD SDK to talk to the 3D Systems Touch.  Links
+against the proprietary @code{openhaptics-sdk} and pulls in
+@code{touch-driver} at runtime.")
     (license license:bsd-3)))

--- a/systole/systole/packages/openhaptics.scm
+++ b/systole/systole/packages/openhaptics.scm
@@ -92,13 +92,19 @@
              '("bin/Touch_Diagnostic"
                "bin/Touch_Setup"
                "ListUSBHapticDevices"))
-            (for-each
-             (lambda (rule)
-               (let ((src (string-append payload "/" rule)))
-                 (when (file-exists? src)
-                   (install-file src (string-append out "/lib/udev/rules.d")))))
-             '("lib/udev/rules.d/91-3dsystems-hid.rules"
-               "lib/udev/rules.d/91-3dsystems-touch.rules"))
+            ;; The 2022 driver tarball doesn't ship udev rules.
+            ;; Create one for the Touch USB device (vendor 2988).
+            (let ((rules-dir (string-append out "/lib/udev/rules.d")))
+              (mkdir-p rules-dir)
+              (call-with-output-file
+                  (string-append rules-dir "/91-3dsystems-touch.rules")
+                (lambda (port)
+                  (display
+                   (string-append
+                    "# 3D Systems Touch haptic device — grant rw to all users\n"
+                    "SUBSYSTEM==\"tty\", ATTRS{idVendor}==\"2988\", "
+                    "ATTRS{idProduct}==\"0302\", MODE=\"0666\"\n")
+                   port))))
             ;; Patchelf the pre-built binaries so they use the Guix
             ;; dynamic linker + find their Qt5 / PhantomIO deps.
             (let* ((patchelf (string-append

--- a/systole/systole/packages/openhaptics.scm
+++ b/systole/systole/packages/openhaptics.scm
@@ -1,0 +1,257 @@
+;;
+;; Copyright @ 2026 Oslo University Hospital
+;;
+;; This file is part of SystoleOS.
+;;
+;; SystoleOS is free software: you can redistribute it and/or modify it under the
+;; terms of the GNU General Public License as published by the Free Software
+;; Foundation, either version 3 of the License, or (at your option) any later version.
+;;
+;; SystoleOS is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+;; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+;; PURPOSE. See the GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License along
+;; with SystoleOS. If not, see <https://www.gnu.org/licenses/>.
+;;
+
+;;; Commentary:
+;;;
+;;; Non-free packages for the 3D Systems Touch (formerly Sensable Phantom
+;;; Omni) haptic device.  Two tarballs are pulled from 3D Systems' public
+;;; S3 bucket:
+;;;
+;;;   * openhaptics-sdk  — OpenHaptics 3.4 Developer Edition SDK
+;;;                        (libHD, libHL, libQH, headers, .a files).
+;;;   * touch-driver     — the Touch 2022 USB user-space driver providing
+;;;                        libPhantomIOLib42.so (required at runtime by
+;;;                        libHD) and the Touch_Diagnostic / Touch_Setup
+;;;                        utilities + udev rules.
+;;;
+;;; Both are distributed under a proprietary EULA from 3D Systems; they
+;;; are freely downloadable (no login) but not redistributable under a
+;;; free license.  They exist here so the JHU cisst sawSensablePhantom
+;;; stack — and through it Laura Connolly's SlicerROS2 Touch demo — can
+;;; be built in a hermetic Guix environment.
+;;;
+;;; Code:
+
+(define-module (systole packages openhaptics)
+  #:use-module (guix build-system trivial)
+  #:use-module (guix download)
+  #:use-module (guix gexp)
+  #:use-module (guix packages)
+  #:use-module (guix utils)
+  #:use-module (gnu packages base)          ; tar
+  #:use-module (gnu packages compression)   ; gzip
+  #:use-module (gnu packages elf)           ; patchelf
+  #:use-module (gnu packages gcc)           ; gcc:lib
+  #:use-module (nongnu packages ncurses)    ; ncurses-5 (nonguix channel)
+  #:use-module ((systole licenses) #:prefix license:))
+
+;;;
+;;; 3D Systems Touch USB driver 2022-04-04 (proprietary).
+;;; Defined first so openhaptics-sdk can propagate it.
+;;;
+
+(define-public touch-driver
+  (package
+    (name "touch-driver")
+    (version "2022-04-04")
+    (source
+     (origin
+       (method url-fetch)
+       (uri "https://s3.amazonaws.com/dl.3dsystems.com/binaries/Sensable/Linux/TouchDriver2022_04_04.tgz")
+       (sha256
+        (base32 "0qygavn85mvaaawsy9swqn6y2snxdnl4bz4nam8nydzykz7qsxkv"))))
+    (build-system trivial-build-system)
+    (arguments
+     (list
+      #:modules '((guix build utils))
+      #:builder
+      #~(begin
+          (use-modules (guix build utils))
+          (let* ((out     #$output)
+                 (tar     (string-append #$(this-package-native-input "tar")
+                                         "/bin/tar"))
+                 (gzip    (string-append #$(this-package-native-input "gzip")
+                                         "/bin"))
+                 (payload "TouchDriver2022_04_04"))
+            (setenv "PATH" (string-append gzip ":" (getenv "PATH")))
+            (invoke tar "xf" #$source)
+            (mkdir-p (string-append out "/lib"))
+            (mkdir-p (string-append out "/bin"))
+            (mkdir-p (string-append out "/lib/udev/rules.d"))
+            (install-file (string-append payload "/usr/lib/libPhantomIOLib42.so")
+                          (string-append out "/lib"))
+            (for-each
+             (lambda (f)
+               (let ((src (string-append payload "/" f)))
+                 (when (file-exists? src)
+                   (install-file src (string-append out "/bin")))))
+             '("bin/Touch_Diagnostic"
+               "bin/Touch_Setup"
+               "ListUSBHapticDevices"))
+            (for-each
+             (lambda (rule)
+               (let ((src (string-append payload "/" rule)))
+                 (when (file-exists? src)
+                   (install-file src (string-append out "/lib/udev/rules.d")))))
+             '("lib/udev/rules.d/91-3dsystems-hid.rules"
+               "lib/udev/rules.d/91-3dsystems-touch.rules"))))))
+    (native-inputs
+     (list (@ (gnu packages base) tar)
+           (@ (gnu packages compression) gzip)))
+    (supported-systems '("x86_64-linux"))
+    (home-page "https://www.3dsystems.com/haptics-devices/touch")
+    (synopsis "3D Systems Touch USB user-space driver (proprietary)")
+    (description
+     "User-space USB driver for the 3D Systems Touch haptic device
+(formerly the Sensable Phantom Omni).  Provides @code{libPhantomIOLib42}
+— the runtime library that @code{libHD} from OpenHaptics dlopen()'s to
+talk to the device over USB — plus the @code{Touch_Diagnostic} and
+@code{Touch_Setup} calibration utilities and the @file{91-3dsystems-*}
+udev rules that let non-root users open the device.
+
+This package is non-free and is distributed directly by 3D Systems
+from their public S3 bucket under a proprietary EULA.")
+    (license license:3ds-touch-driver-eula)))
+
+;;;
+;;; OpenHaptics 3.4 Developer Edition SDK (proprietary).
+;;;
+
+(define-public openhaptics-sdk
+  (package
+    (name "openhaptics-sdk")
+    (version "3.4-0")
+    (source
+     (origin
+       (method url-fetch)
+       (uri (string-append
+             "https://s3.amazonaws.com/dl.3dsystems.com/binaries/"
+             "support/downloads/KB+Files/Open+Haptics/"
+             "openhaptics_" version "-developer-edition-amd64.tar.gz"))
+       (sha256
+        (base32 "07r7f9pgvqmzljwq32yp14apjkpy3p2a2wn6bsic1n54lhwy0s4h"))))
+    (build-system trivial-build-system)
+    (arguments
+     (list
+      #:modules '((guix build utils))
+      #:builder
+      #~(begin
+          (use-modules (guix build utils))
+          (let* ((out     #$output)
+                 (tar     (string-append #$(this-package-native-input "tar")
+                                         "/bin/tar"))
+                 (gzip    (string-append #$(this-package-native-input "gzip")
+                                         "/bin"))
+                 (patchelf (string-append
+                            #$(this-package-native-input "patchelf")
+                            "/bin/patchelf"))
+                 (payload "openhaptics_3.4-0-developer-edition-amd64"))
+            (setenv "PATH" (string-append gzip ":" (getenv "PATH")))
+            (invoke tar "xf" #$source)
+            ;; SDK layout after extraction:
+            ;;   <payload>/usr/include/{HD,HDU,HL,HLU,QH,SnapConstraints}
+            ;;   <payload>/usr/lib/lib{HD,HL,QH,QHGLUTWrapper}.so.3.4.0
+            ;;   <payload>/usr/lib/lib{HDU,HLU,SnapConstraints}.a
+            ;;   <payload>/opt/OpenHaptics/Developer/3.4-0/{doc,examples}
+            (mkdir-p (string-append out "/include"))
+            (mkdir-p (string-append out "/lib"))
+            (mkdir-p (string-append out "/share/doc/openhaptics-3.4"))
+            (for-each
+             (lambda (d)
+               (copy-recursively
+                (string-append payload "/usr/include/" d)
+                (string-append out "/include/" d)))
+             '("HD" "HDU" "HL" "HLU" "QH" "SnapConstraints"))
+            (for-each
+             (lambda (f)
+               (install-file (string-append payload "/usr/lib/" f)
+                             (string-append out "/lib")))
+             '("libHD.so.3.4.0"
+               "libHL.so.3.4.0"
+               "libQH.so.3.4.0"
+               "libQHGLUTWrapper.so.3.4.0"
+               "libHDU.a"
+               "libHLU.a"
+               "libSnapConstraints.a"))
+            ;; Create the .so and .so.3.4 symlinks libHL expects.
+            (with-directory-excursion (string-append out "/lib")
+              (for-each
+               (lambda (base)
+                 (symlink (string-append base ".so.3.4.0")
+                          (string-append base ".so.3.4"))
+                 (symlink (string-append base ".so.3.4.0")
+                          (string-append base ".so")))
+               '("libHD" "libHL" "libQH" "libQHGLUTWrapper")))
+            ;; Patch RUNPATH on the .so files so libHD finds its
+            ;; dependencies (libPhantomIOLib42 from touch-driver,
+            ;; libncurses.so.5/libtinfo.so.5 from ncurses-5, and the
+            ;; usual libstdc++/libgcc_s from gcc:lib) without the
+            ;; user having to set LD_LIBRARY_PATH manually.  The
+            ;; touch-driver path is injected as a propagated input,
+            ;; so its $out/lib must appear in RUNPATH too — we add
+            ;; it as a relative $ORIGIN fallback and rely on
+            ;; LD_LIBRARY_PATH plumbing via native-search-paths.
+            (let ((rpath
+                   (string-append
+                    "$ORIGIN:"
+                    #$(this-package-input "ncurses") "/lib:"
+                    #$(this-package-input "gcc:lib") "/lib")))
+              (for-each
+               (lambda (f)
+                 (invoke patchelf "--set-rpath" rpath
+                         (string-append out "/lib/" f)))
+               '("libHD.so.3.4.0"
+                 "libHL.so.3.4.0"
+                 "libQH.so.3.4.0"
+                 "libQHGLUTWrapper.so.3.4.0")))
+            ;; Copy examples and docs (small).
+            (copy-recursively
+             (string-append payload "/opt/OpenHaptics/Developer/3.4-0/doc")
+             (string-append out "/share/doc/openhaptics-3.4/doc"))
+            (copy-recursively
+             (string-append payload
+                            "/opt/OpenHaptics/Developer/3.4-0/examples")
+             (string-append out "/share/doc/openhaptics-3.4/examples"))
+            ;; Symbolic Developer tree some build systems look for via
+            ;; $OH_SDK_BASE; mirror the canonical /opt/OpenHaptics layout.
+            (mkdir-p (string-append out "/opt/OpenHaptics/Developer/3.4-0"))
+            (symlink (string-append out "/include")
+                     (string-append out
+                                    "/opt/OpenHaptics/Developer/3.4-0/include"))
+            (symlink (string-append out "/lib")
+                     (string-append out
+                                    "/opt/OpenHaptics/Developer/3.4-0/lib"))))))
+    (native-inputs
+     (list (@ (gnu packages base) tar)
+           (@ (gnu packages compression) gzip)
+           (@ (gnu packages elf) patchelf)))
+    (inputs
+     ;; libHD needs libncurses.so.5 + libtinfo.so.5 (legacy ABI).
+     ;; Guix proper only ships ncurses@6; nonguix ships ncurses-5.9.
+     ;; gcc:lib gives libstdc++/libgcc_s.
+     `(("ncurses" ,(@ (nongnu packages ncurses) ncurses-5))
+       ("gcc:lib" ,(@ (gnu packages gcc) gcc) "lib")))
+    ;; libHD DT_NEEDED's libPhantomIOLib42.so which lives in
+    ;; touch-driver; propagate so anything that installs
+    ;; openhaptics-sdk also gets the driver on LD_LIBRARY_PATH.
+    (propagated-inputs (list touch-driver))
+    (supported-systems '("x86_64-linux"))
+    (home-page "https://www.3dsystems.com/haptics-devices/openhaptics")
+    (synopsis "OpenHaptics 3.4 Developer Edition SDK (proprietary)")
+    (description
+     "OpenHaptics is the C/C++ SDK from 3D Systems used to program the
+Touch (Sensable Phantom Omni) family of haptic devices.  This package
+unpacks the Linux Developer Edition 3.4 tarball from 3D Systems' public
+S3 bucket and installs @file{libHD}, @file{libHL}, @file{libQH} and the
+matching @file{HD}, @file{HDU}, @file{HL}, @file{HLU} headers into the
+store under a standard @file{include}/@file{lib} layout.
+
+This package is non-free.  At runtime @code{libHD.so} dlopen()'s
+@file{libPhantomIOLib42.so} from the companion @code{touch-driver}
+package, which must be installed and a Touch device physically present
+before @code{hdInitDevice} will succeed.")
+    (license license:openhaptics-eula)))

--- a/systole/systole/packages/openhaptics.scm
+++ b/systole/systole/packages/openhaptics.scm
@@ -98,10 +98,38 @@
                  (when (file-exists? src)
                    (install-file src (string-append out "/lib/udev/rules.d")))))
              '("lib/udev/rules.d/91-3dsystems-hid.rules"
-               "lib/udev/rules.d/91-3dsystems-touch.rules"))))))
+               "lib/udev/rules.d/91-3dsystems-touch.rules"))
+            ;; Patchelf the pre-built binaries so they use the Guix
+            ;; dynamic linker + find their Qt5 / PhantomIO deps.
+            (let* ((patchelf (string-append
+                              #$(this-package-native-input "patchelf")
+                              "/bin/patchelf"))
+                   (ld-linux (string-append
+                              #$(this-package-input "glibc")
+                              "/lib/ld-linux-x86-64.so.2"))
+                   (gcc-lib-path
+                    ;; gcc "lib" output lives at a separate store path
+                    ;; (-gcc-14.x-lib).  Resolve via %build-inputs.
+                    (or (assoc-ref %build-inputs "gcc:lib")
+                        (error "gcc:lib input not found")))
+                   (rpath (string-append
+                           out "/lib:"
+                           gcc-lib-path "/lib:"
+                           #$(this-package-input "glibc") "/lib")))
+              (for-each
+               (lambda (bin)
+                 (let ((f (string-append out "/bin/" bin)))
+                   (when (file-exists? f)
+                     (invoke patchelf "--set-interpreter" ld-linux f)
+                     (invoke patchelf "--set-rpath" rpath f))))
+               '("Touch_Diagnostic" "Touch_Setup")))))))
     (native-inputs
      (list (@ (gnu packages base) tar)
-           (@ (gnu packages compression) gzip)))
+           (@ (gnu packages compression) gzip)
+           (@ (gnu packages elf) patchelf)))
+    (inputs
+     `(("glibc" ,(@ (gnu packages base) glibc))
+       ("gcc:lib" ,(@ (gnu packages gcc) gcc) "lib")))
     (supported-systems '("x86_64-linux"))
     (home-page "https://www.3dsystems.com/haptics-devices/touch")
     (synopsis "3D Systems Touch USB user-space driver (proprietary)")

--- a/systole/systole/packages/openhaptics.scm
+++ b/systole/systole/packages/openhaptics.scm
@@ -231,9 +231,10 @@ from their public S3 bucket under a proprietary EULA.")
            (@ (gnu packages elf) patchelf)))
     (inputs
      ;; libHD needs libncurses.so.5 + libtinfo.so.5 (legacy ABI).
-     ;; Guix proper only ships ncurses@6; nonguix ships ncurses-5.9.
-     ;; gcc:lib gives libstdc++/libgcc_s.
-     `(("ncurses" ,(@ (nongnu packages ncurses) ncurses-5))
+     ;; Must use ncurses/tinfo-5 (not ncurses-5) so libtinfo.so.5 is
+     ;; split out as a separate shared library — libHD DT_NEEDs it
+     ;; independently.  gcc:lib gives libstdc++/libgcc_s.
+     `(("ncurses" ,(@ (nongnu packages ncurses) ncurses/tinfo-5))
        ("gcc:lib" ,(@ (gnu packages gcc) gcc) "lib")))
     ;; libHD DT_NEEDED's libPhantomIOLib42.so which lives in
     ;; touch-driver; propagate so anything that installs

--- a/systole/systole/packages/patches/ros2/jazzy/cisst-ros-fix-name-resize.patch
+++ b/systole/systole/packages/patches/ros2/jazzy/cisst-ros-fix-name-resize.patch
@@ -1,12 +1,11 @@
 Fix build against cisst 1.4: prmStateJoint::Name() returns
-std::vector<std::string>&, which has no SetSize() method — use the
-standard resize() member instead.
+std::vector<std::string>& (no SetSize() method) — use resize().
 
---- a/src/mtsROSToCISST.cpp
-+++ b/src/mtsROSToCISST.cpp
-@@ -279,7 +279,7 @@
-
- void mtsROSToCISST(const sensor_msgs::msg::JointState & rosData, prmStateJoint & cisstData)
+--- a/cisst_ros_bridge/src/mtsROSToCISST.cpp
++++ b/cisst_ros_bridge/src/mtsROSToCISST.cpp
+@@ -319,7 +319,7 @@
+ void mtsROSToCISST(const CISST_RAL_MSG(sensor_msgs, JointState) & rosData,
+                    prmStateJoint & cisstData)
  {
 -    cisstData.Name().SetSize(rosData.name.size());
 +    cisstData.Name().resize(rosData.name.size());

--- a/systole/systole/packages/patches/ros2/jazzy/cisst_ros2_bridge-fix-name-resize.patch
+++ b/systole/systole/packages/patches/ros2/jazzy/cisst_ros2_bridge-fix-name-resize.patch
@@ -1,0 +1,15 @@
+Fix build against cisst 1.4: prmStateJoint::Name() returns
+std::vector<std::string>&, which has no SetSize() method — use the
+standard resize() member instead.
+
+--- a/src/mtsROSToCISST.cpp
++++ b/src/mtsROSToCISST.cpp
+@@ -279,7 +279,7 @@
+
+ void mtsROSToCISST(const sensor_msgs::msg::JointState & rosData, prmStateJoint & cisstData)
+ {
+-    cisstData.Name().SetSize(rosData.name.size());
++    cisstData.Name().resize(rosData.name.size());
+     std::copy(rosData.name.begin(), rosData.name.end(),
+               cisstData.Name().begin());
+     cisstData.Position().SetSize(rosData.position.size());

--- a/systole/systole/packages/ros2/jazzy.scm
+++ b/systole/systole/packages/ros2/jazzy.scm
@@ -3718,3 +3718,74 @@ DDS middleware (this is currently the only @code{rmw} implementation
 provided by guix-systole).")
     (home-page "https://docs.ros.org/en/jazzy/")
     (license license:asl2.0)))
+
+;;;
+;;; ros-jazzy-touch — union meta-package for Laura Connolly's Touch demo.
+;;; Same union-build pattern as ros-jazzy to avoid quadratic RAM during
+;;; `guix shell'.  One store path = one profile entry = fast hooks.
+;;;
+
+(define %ros-jazzy-touch-packages
+  (list ros-jazzy
+        ros-sensable-phantom-jazzy
+        ros-saw-controllers-ros-jazzy
+        ros-cisst-ros-bridge-jazzy
+        ros-cisst-ros-crtk-jazzy
+        ros-cisst-msgs-jazzy
+        ros-crtk-msgs-jazzy
+        ros-xacro-jazzy
+        ros-joint-state-publisher-jazzy
+        ros-sensable-omni-model-jazzy
+        ;; Explicitly include the proprietary driver + SDK so the
+        ;; Touch_Setup, Touch_Diagnostic, and ListUSBHapticDevices
+        ;; utilities land in the union's bin/.
+        (@ (systole packages openhaptics) openhaptics-sdk)
+        (@ (systole packages openhaptics) touch-driver)))
+
+(define-public ros-jazzy-touch
+  (package
+    (name "ros-jazzy-touch")
+    (version "0.1.0")
+    (source #f)
+    (build-system trivial-build-system)
+    (arguments
+     (list #:modules '((guix build union)
+                       (guix build utils)
+                       (srfi srfi-1))
+           #:builder
+           (with-imported-modules '((guix build union)
+                                    (guix build utils))
+             #~(begin
+                 (use-modules (guix build union)
+                              (guix build utils)
+                              (srfi srfi-1)
+                              (ice-9 match))
+                 (let ((out #$output)
+                       (inputs (map cdr %build-inputs)))
+                   (union-build out inputs
+                                #:create-all-directories? #t)
+                   #t)))))
+    (inputs
+     (let ((direct %ros-jazzy-touch-packages))
+       (delete-duplicates
+        (append direct
+                (append-map
+                 (lambda (pkg)
+                   (map (match-lambda ((_ p . _) p))
+                        (package-transitive-propagated-inputs pkg)))
+                 direct))
+        eq?)))
+    (native-search-paths (ros2-native-search-paths jazzy-distro))
+    (synopsis "ROS 2 Jazzy + 3D Systems Touch haptic device demo")
+    (description
+     "Union meta-package bundling @code{ros-jazzy} with the full Touch
+haptic device stack: the @code{sensable_phantom} ROS 2 node, the
+cisst/SAW framework, the CRTK bridge, the Touch URDF model, and the
+proprietary OpenHaptics SDK + USB driver.  Run with:
+
+@example
+guix shell ros-jazzy-touch
+ros2 run sensable_phantom sensable_phantom -D
+@end example")
+    (home-page "https://github.com/jhu-saw/sawSensablePhantom")
+    (license license:asl2.0)))

--- a/systole/systole/packages/ros2/jazzy.scm
+++ b/systole/systole/packages/ros2/jazzy.scm
@@ -3775,7 +3775,7 @@ provided by guix-systole).")
                        (lambda (port)
                          (display
                           (string-append
-                           "#!/bin/bash\n"
+                           "#!/usr/bin/env bash\n"
                            "# SlicerROS2 + 3D Systems Touch demo launcher.\n"
                            "# Usage: guix shell ros-jazzy-touch -- touch-demo\n"
                            "set -e\n"
@@ -3801,9 +3801,7 @@ provided by guix-systole).")
                            "--ros-args -p \"source_list:=['/arm/measured_js']\" &\n"
                            "JSP=$!; sleep 3\n"
                            "echo '=== Slicer + ROS2 ==='\n"
-                           "Slicer --additional-module-paths "
-                           "$P/lib/Slicer-5.8/qt-loadable-modules "
-                           "$P/lib/Slicer-5.8/qt-scripted-modules &\n"
+                           "Slicer &\n"
                            "echo 'All started. Ctrl+C to stop.'\n"
                            "wait\n")
                           port)))

--- a/systole/systole/packages/ros2/jazzy.scm
+++ b/systole/systole/packages/ros2/jazzy.scm
@@ -3817,7 +3817,20 @@ provided by guix-systole).")
                         (package-transitive-propagated-inputs pkg)))
                  direct))
         eq?)))
-    (native-search-paths (ros2-native-search-paths jazzy-distro))
+    (native-search-paths
+     (append (ros2-native-search-paths jazzy-distro)
+             ;; Slicer module discovery — same paths as slicer-5.8's
+             ;; native-search-paths so the profile hooks set
+             ;; SLICER_ADDITIONAL_MODULE_PATHS without needing
+             ;; slicer-all-5.8 as a separate manifest entry.
+             (list (search-path-specification
+                    (variable "SLICER_ADDITIONAL_MODULE_PATHS")
+                    (files '("lib/Slicer-5.8/qt-loadable-modules"
+                             "lib/Slicer-5.8/cli-modules")))
+                   (search-path-specification
+                    (variable "SLICER_INIT_DIR")
+                    (files '("share/slicer-init"))
+                    (separator #f)))))
     (synopsis "ROS 2 Jazzy + 3D Systems Touch haptic device demo")
     (description
      "Union meta-package bundling @code{ros-jazzy} with the full Touch

--- a/systole/systole/packages/ros2/jazzy.scm
+++ b/systole/systole/packages/ros2/jazzy.scm
@@ -3166,6 +3166,21 @@ parameter) and republishes the merged state on @code{/joint_states}.
 Used by the Touch demo to forward @code{/arm/measured_js} from the
 Sensable Phantom driver into @code{robot_state_publisher}."))
 
+;;
+;; jhu-cisst/cisst-ros is a monorepo containing cisst_msgs,
+;; cisst_ros_bridge and cisst_ros_crtk as three ament sub-packages.
+;; It supersedes the deprecated ros2_cisst_msgs / cisst_ros2_bridge /
+;; cisst_ros2_crtk repos and matches the names sawControllers/ros
+;; and sawSensablePhantom/ros actually use (and provides the
+;; cisst_ral ROS 1/2 abstraction they require).
+;;
+;; Pinned to tag 3.0.0 — introduces the cisst_ral abstraction required
+;; by the saw-components ROS 2 wrappers, without the 4.0.0 additions
+;; (CartesianState, servo_cs) that depend on an unreleased crtk_msgs.
+(define %cisst-ros-commit "5b3884b6f8ab0129ce0277e64cdc2346be9f00e1")
+(define %cisst-ros-hash
+  (base32 "02gpn8nh64gg98l0zw2zny54zf7jkynvlrzszyql67s26vpfzz3y"))
+
 (define-public ros-crtk-msgs-jazzy
   (make-ros2-rosidl-interface-package
    #:distro jazzy-distro
@@ -3184,20 +3199,17 @@ Sensable Phantom driver into @code{robot_state_publisher}."))
    #:synopsis "CRTK (collaborative-robotics) ROS 2 message definitions"
    #:description
    "Interface package for the Collaborative Robotics Toolkit (CRTK)
-naming convention used by the JHU cisst-SAW stack: OperatingState,
-StringStamped, CartesianImpedance*, TriggerOperatingState,
-QueryForwardKinematics, QueryInverseKinematics.  Required by
-@code{cisst_ros2_crtk} and, transitively, the sawSensablePhantom
-ROS 2 bridge."))
+naming convention used by the JHU cisst-SAW stack."))
 
 (define-public ros-cisst-msgs-jazzy
   (make-ros2-rosidl-interface-package
    #:distro jazzy-distro
    #:ros-name "cisst_msgs"
-   #:version "2.1.0"
-   #:repo "https://github.com/jhu-cisst/ros2_cisst_msgs"
-   #:commit "2addbab1afc3c998b95435baa16c6363f4b2e5ab"
-   #:hash (base32 "14spwl982bc7r2lbxdcxlx2lynwvx6ja0wnjn8simfhz3296gh2v")
+   #:version "3.0.0"
+   #:repo "https://github.com/jhu-cisst/cisst-ros"
+   #:commit %cisst-ros-commit
+   #:hash %cisst-ros-hash
+   #:module-subdir "cisst_msgs"
    #:message-deps (list ros-rosidl-default-generators-jazzy
                         ros-rosidl-default-runtime-jazzy
                         ros-builtin-interfaces-jazzy
@@ -3205,31 +3217,30 @@ ROS 2 bridge."))
                         ros-std-msgs-jazzy
                         ros-sensor-msgs-jazzy
                         ros-geometry-msgs-jazzy)
-   #:home-page "https://github.com/jhu-cisst/ros2_cisst_msgs"
+   #:home-page "https://github.com/jhu-cisst/cisst-ros"
    #:synopsis "JHU cisst-specific ROS 2 message definitions"
    #:description
-   "Interface package for cisst-specific ROS 2 messages: BoolStamped,
-DoubleVec, IntervalStatistics and a ConvertFloat64Array service.
-Consumed by @code{cisst_ros2_bridge} to translate cisst component
-state onto standard ROS 2 topics."))
+   "Interface package for cisst-specific ROS 2 messages (BoolStamped,
+DoubleVec, IntervalStatistics, ConvertFloat64Array).  Sub-package of
+the jhu-cisst/cisst-ros monorepo."))
 
-(define-public ros-cisst-ros2-bridge-jazzy
+(define-public ros-cisst-ros-bridge-jazzy
   (make-ros2-ament-cmake-package
    #:distro jazzy-distro
-   #:ros-name "cisst_ros2_bridge"
-   #:version "2.1.0"
-   #:repo "https://github.com/jhu-cisst/cisst_ros2_bridge"
-   #:commit "119a77d31e2dbaf54a26eef55ba092fc50a4cacd"
-   #:hash (base32 "0dznqqilasw55cnj07fnpiv61hq63haixxsgvigmpn288g00cf5x")
+   #:ros-name "cisst_ros_bridge"
+   #:version "3.0.0"
+   #:repo "https://github.com/jhu-cisst/cisst-ros"
+   #:commit %cisst-ros-commit
+   #:hash %cisst-ros-hash
+   #:module-subdir "cisst_ros_bridge"
+   ;; cisst 1.4's prmStateJoint::Name() returns std::vector<std::string>&;
+   ;; patch mtsROSToCISST.cpp to call resize() instead of SetSize().
+   #:patches '("cisst-ros-fix-name-resize.patch")
    #:extra-inputs (list cisst cisst-netlib)
    #:extra-configure-flags
    #~(list (string-append "-Dcisst_DIR="
                           #$cisst
                           "/share/cisst-1.4/cmake"))
-   ;; Upstream's mtsROSToCISST.cpp calls cisstData.Name().SetSize(...)
-   ;; but in cisst 1.4 prmStateJoint::Name() returns
-   ;; std::vector<std::string>& which uses .resize().  Patch it.
-   #:patches '("cisst_ros2_bridge-fix-name-resize.patch")
    #:propagated-inputs (list ros-ament-cmake-jazzy
                              ros-rclcpp-jazzy
                              ros-std-msgs-jazzy
@@ -3240,30 +3251,31 @@ state onto standard ROS 2 topics."))
                              ros-cisst-msgs-jazzy
                              ros-tf2-ros-jazzy
                              ros-tf2-msgs-jazzy)
-   #:home-page "https://github.com/jhu-cisst/cisst_ros2_bridge"
+   #:home-page "https://github.com/jhu-cisst/cisst-ros"
    #:synopsis "Bridge cisst/SAW multi-task components to ROS 2 topics"
    #:description
-   "@code{cisst_ros2_bridge} provides @code{mtsROSBridge}, the
-translation layer between cisst's @code{mtsComponent} interfaces and
-ROS 2 publishers/subscribers.  Consumed by the JHU @code{saw*}
-components — including @code{sawSensablePhantom} — to publish haptic
-device state on standard ROS 2 topics."))
+   "@code{cisst_ros_bridge} (from the jhu-cisst/cisst-ros monorepo)
+provides @code{mtsROSBridge} — the translation layer between cisst's
+@code{mtsComponent} interfaces and ROS 2 publishers/subscribers — plus
+the @code{cisst_ral} ROS 1/2 abstraction namespace consumed by the
+saw-components' ROS wrappers."))
 
-(define-public ros-cisst-ros2-crtk-jazzy
+(define-public ros-cisst-ros-crtk-jazzy
   (make-ros2-ament-cmake-package
    #:distro jazzy-distro
-   #:ros-name "cisst_ros2_crtk"
-   #:version "2.1.0"
-   #:repo "https://github.com/jhu-cisst/cisst_ros2_crtk"
-   #:commit "763a848db5011a0445b746448472f41319c437c6"
-   #:hash (base32 "1z0nbi93kamvvd22crlixillxsalhbnhndjbsmxqv162ljyw8f8b")
+   #:ros-name "cisst_ros_crtk"
+   #:version "3.0.0"
+   #:repo "https://github.com/jhu-cisst/cisst-ros"
+   #:commit %cisst-ros-commit
+   #:hash %cisst-ros-hash
+   #:module-subdir "cisst_ros_crtk"
    #:extra-inputs (list cisst cisst-netlib)
    #:extra-configure-flags
    #~(list (string-append "-Dcisst_DIR="
                           #$cisst
                           "/share/cisst-1.4/cmake"))
    #:propagated-inputs (list ros-ament-cmake-jazzy
-                             ros-cisst-ros2-bridge-jazzy
+                             ros-cisst-ros-bridge-jazzy
                              ros-crtk-msgs-jazzy
                              ros-rclcpp-jazzy
                              ros-std-msgs-jazzy
@@ -3274,15 +3286,15 @@ device state on standard ROS 2 topics."))
                              ros-cisst-msgs-jazzy
                              ros-tf2-ros-jazzy
                              ros-tf2-msgs-jazzy)
-   #:home-page "https://github.com/jhu-cisst/cisst_ros2_crtk"
+   #:home-page "https://github.com/jhu-cisst/cisst-ros"
    #:synopsis "CRTK (collaborative robotics) ROS 2 bridge for cisst"
    #:description
-   "@code{cisst_ros2_crtk} layers the CRTK naming convention on top of
-@code{cisst_ros2_bridge}: @code{mts_ros_crtk_bridge_provided} exposes
-all CRTK interfaces (@code{measured_js}, @code{measured_cp},
-@code{servo_cf}, @code{operating_state}, ...) of an @code{mtsComponent}
-as ROS 2 topics/services with consistent names.  Used by the JHU
-@code{sawSensablePhantom} ROS 2 node to speak CRTK."))
+   "@code{cisst_ros_crtk} (from the jhu-cisst/cisst-ros monorepo)
+layers the CRTK naming convention on top of @code{cisst_ros_bridge}:
+@code{mts_ros_crtk_bridge_provided} exposes all CRTK interfaces
+(@code{measured_js}, @code{measured_cp}, @code{servo_cf},
+@code{operating_state}, ...) of an @code{mtsComponent} as ROS 2
+topics/services."))
 
 (define-public ros-sensable-omni-model-jazzy
   (make-ros2-ament-python-package

--- a/systole/systole/packages/ros2/jazzy.scm
+++ b/systole/systole/packages/ros2/jazzy.scm
@@ -50,6 +50,7 @@
   #:use-module (gnu packages xml)          ; tinyxml2
   #:use-module (systole packages ros2)
   #:use-module (systole packages ros2-helpers) ; urdfdom, urdfdom-headers, console-bridge
+  #:use-module (systole packages cisst)         ; cisst, cisst-netlib (Touch demo)
   #:use-module (srfi srfi-1)               ; delete-duplicates, append-map
   #:use-module (ice-9 match)               ; match-lambda
   #:export (jazzy-distro))
@@ -3211,6 +3212,77 @@ ROS 2 bridge."))
 DoubleVec, IntervalStatistics and a ConvertFloat64Array service.
 Consumed by @code{cisst_ros2_bridge} to translate cisst component
 state onto standard ROS 2 topics."))
+
+(define-public ros-cisst-ros2-bridge-jazzy
+  (make-ros2-ament-cmake-package
+   #:distro jazzy-distro
+   #:ros-name "cisst_ros2_bridge"
+   #:version "2.1.0"
+   #:repo "https://github.com/jhu-cisst/cisst_ros2_bridge"
+   #:commit "119a77d31e2dbaf54a26eef55ba092fc50a4cacd"
+   #:hash (base32 "0dznqqilasw55cnj07fnpiv61hq63haixxsgvigmpn288g00cf5x")
+   #:extra-inputs (list cisst cisst-netlib)
+   #:extra-configure-flags
+   #~(list (string-append "-Dcisst_DIR="
+                          #$cisst
+                          "/share/cisst-1.4/cmake"))
+   ;; Upstream's mtsROSToCISST.cpp calls cisstData.Name().SetSize(...)
+   ;; but in cisst 1.4 prmStateJoint::Name() returns
+   ;; std::vector<std::string>& which uses .resize().  Patch it.
+   #:patches '("cisst_ros2_bridge-fix-name-resize.patch")
+   #:propagated-inputs (list ros-ament-cmake-jazzy
+                             ros-rclcpp-jazzy
+                             ros-std-msgs-jazzy
+                             ros-std-srvs-jazzy
+                             ros-geometry-msgs-jazzy
+                             ros-sensor-msgs-jazzy
+                             ros-diagnostic-msgs-jazzy
+                             ros-cisst-msgs-jazzy
+                             ros-tf2-ros-jazzy
+                             ros-tf2-msgs-jazzy)
+   #:home-page "https://github.com/jhu-cisst/cisst_ros2_bridge"
+   #:synopsis "Bridge cisst/SAW multi-task components to ROS 2 topics"
+   #:description
+   "@code{cisst_ros2_bridge} provides @code{mtsROSBridge}, the
+translation layer between cisst's @code{mtsComponent} interfaces and
+ROS 2 publishers/subscribers.  Consumed by the JHU @code{saw*}
+components — including @code{sawSensablePhantom} — to publish haptic
+device state on standard ROS 2 topics."))
+
+(define-public ros-cisst-ros2-crtk-jazzy
+  (make-ros2-ament-cmake-package
+   #:distro jazzy-distro
+   #:ros-name "cisst_ros2_crtk"
+   #:version "2.1.0"
+   #:repo "https://github.com/jhu-cisst/cisst_ros2_crtk"
+   #:commit "763a848db5011a0445b746448472f41319c437c6"
+   #:hash (base32 "1z0nbi93kamvvd22crlixillxsalhbnhndjbsmxqv162ljyw8f8b")
+   #:extra-inputs (list cisst cisst-netlib)
+   #:extra-configure-flags
+   #~(list (string-append "-Dcisst_DIR="
+                          #$cisst
+                          "/share/cisst-1.4/cmake"))
+   #:propagated-inputs (list ros-ament-cmake-jazzy
+                             ros-cisst-ros2-bridge-jazzy
+                             ros-crtk-msgs-jazzy
+                             ros-rclcpp-jazzy
+                             ros-std-msgs-jazzy
+                             ros-std-srvs-jazzy
+                             ros-geometry-msgs-jazzy
+                             ros-sensor-msgs-jazzy
+                             ros-diagnostic-msgs-jazzy
+                             ros-cisst-msgs-jazzy
+                             ros-tf2-ros-jazzy
+                             ros-tf2-msgs-jazzy)
+   #:home-page "https://github.com/jhu-cisst/cisst_ros2_crtk"
+   #:synopsis "CRTK (collaborative robotics) ROS 2 bridge for cisst"
+   #:description
+   "@code{cisst_ros2_crtk} layers the CRTK naming convention on top of
+@code{cisst_ros2_bridge}: @code{mts_ros_crtk_bridge_provided} exposes
+all CRTK interfaces (@code{measured_js}, @code{measured_cp},
+@code{servo_cf}, @code{operating_state}, ...) of an @code{mtsComponent}
+as ROS 2 topics/services with consistent names.  Used by the JHU
+@code{sawSensablePhantom} ROS 2 node to speak CRTK."))
 
 (define-public ros-sensable-omni-model-jazzy
   (make-ros2-ament-python-package

--- a/systole/systole/packages/ros2/jazzy.scm
+++ b/systole/systole/packages/ros2/jazzy.scm
@@ -3110,6 +3110,81 @@ occupancy maps between ROS 2 nodes; required by @code{moveit_msgs}."))
 package; required by the SlicerROS2 module."))
 
 ;;;
+;;; Touch haptic-device demo support (Laura Connolly's VirtualFixture
+;;; reproducer).  The stack is:
+;;;
+;;;   xacro + joint_state_publisher + robot_state_publisher
+;;;     -> parses ros2_sensable_omni_model URDF and publishes /tf
+;;;   cisst + sawSensablePhantom[ROS2]  (packaged separately)
+;;;     -> drives the 3D Systems Touch via OpenHaptics HD
+;;;        and bridges CRTK topics onto ROS 2
+;;;
+;;; These are the pure-ament helpers required even before we tackle the
+;;; cisst/saw stack; they are useful independent of the Touch demo too.
+;;;
+
+(define-public ros-xacro-jazzy
+  (make-ros2-ament-cmake-package
+   #:distro jazzy-distro
+   #:ros-name "xacro"
+   #:version "2.1.1"
+   #:repo "https://github.com/ros/xacro"
+   #:commit "da4b3849f8320903d625250089f67f0632be86f2"
+   #:hash (base32 "19pirchr0xi02ky1ijyiaqi8j8s2pcyp6irv9f4538y2iiavnwk3")
+   #:propagated-inputs (list ros-ament-cmake-jazzy
+                             ros-ament-cmake-python-jazzy
+                             ros-ament-index-python-jazzy
+                             python-pyyaml)
+   #:home-page "https://github.com/ros/xacro"
+   #:synopsis "XML macro language for URDF"
+   #:description
+   "@code{xacro} is the standard XML macro language used by ROS robot
+description files to generate URDF from parameterised templates.  The
+@command{xacro} command is invoked at launch time by the Touch demo's
+@code{sensable_phantom_rviz.launch.py} to expand the URDF shipped in
+@code{sensable_omni_model}."))
+
+(define-public ros-joint-state-publisher-jazzy
+  (make-ros2-ament-python-package
+   #:distro jazzy-distro
+   #:ros-name "joint_state_publisher"
+   #:version "2.4.1"
+   #:repo "https://github.com/ros/joint_state_publisher"
+   #:commit "e535250131aaccafce227ef124dbbd8b0a466f23"
+   #:hash (base32 "0jmjc84bznv9r5ghflf5z52vfbqsa8bxksj548jvps9gxg6zxssr")
+   #:module-subdir "joint_state_publisher"
+   #:propagated-inputs (list ros-rclpy-jazzy
+                             ros-sensor-msgs-jazzy
+                             ros-std-msgs-jazzy)
+   #:home-page "https://github.com/ros/joint_state_publisher"
+   #:synopsis "Aggregate joint state sources into a single /joint_states topic"
+   #:description
+   "@code{joint_state_publisher} is a ROS 2 node that subscribes to one
+or more @code{sensor_msgs/JointState} topics (its @var{source_list}
+parameter) and republishes the merged state on @code{/joint_states}.
+Used by the Touch demo to forward @code{/arm/measured_js} from the
+Sensable Phantom driver into @code{robot_state_publisher}."))
+
+(define-public ros-sensable-omni-model-jazzy
+  (make-ros2-ament-python-package
+   #:distro jazzy-distro
+   #:ros-name "sensable_omni_model"
+   #:version "0.0.0"
+   #:repo "https://github.com/jhu-saw/ros2_sensable_omni_model"
+   #:commit "0af819b9b7547ebe5b6ad0c316b81faa5a321b14"
+   #:hash (base32 "0ijyryar7fmxinfm2lg2fi0vvxrs8cnzam592yh3bsmq4w26vdks")
+   #:propagated-inputs (list ros-rclpy-jazzy
+                             ros-sensor-msgs-jazzy)
+   #:license license:expat
+   #:home-page "https://github.com/jhu-saw/ros2_sensable_omni_model"
+   #:synopsis "URDF and mesh model of the 3D Systems Touch (Sensable Omni)"
+   #:description
+   "Pure-data ament package containing the URDF, xacro, STL meshes, and
+an RViz config for the 3D Systems Touch haptic device (formerly the
+Sensable Phantom Omni).  Consumed by @code{robot_state_publisher} when
+running Laura Connolly's SlicerROS2 Touch teleoperation demo."))
+
+;;;
 ;;; Aggregation meta-package.
 ;;;
 ;;; Phase 1 will grow this package's propagated-inputs tier by tier until

--- a/systole/systole/packages/ros2/jazzy.scm
+++ b/systole/systole/packages/ros2/jazzy.scm
@@ -3165,6 +3165,53 @@ parameter) and republishes the merged state on @code{/joint_states}.
 Used by the Touch demo to forward @code{/arm/measured_js} from the
 Sensable Phantom driver into @code{robot_state_publisher}."))
 
+(define-public ros-crtk-msgs-jazzy
+  (make-ros2-rosidl-interface-package
+   #:distro jazzy-distro
+   #:ros-name "crtk_msgs"
+   #:version "1.1.0"
+   #:repo "https://github.com/collaborative-robotics/ros2_crtk_msgs"
+   #:commit "444014f8f63544a59f34e78e8fd1891256f10dac"
+   #:hash (base32 "0015ipvrk14ab713sy48p0ygw4mm99afsh45snx25ppfh2h6aakh")
+   #:message-deps (list ros-rosidl-default-generators-jazzy
+                        ros-rosidl-default-runtime-jazzy
+                        ros-builtin-interfaces-jazzy
+                        ros-rclcpp-jazzy
+                        ros-std-msgs-jazzy
+                        ros-geometry-msgs-jazzy)
+   #:home-page "https://github.com/collaborative-robotics/ros2_crtk_msgs"
+   #:synopsis "CRTK (collaborative-robotics) ROS 2 message definitions"
+   #:description
+   "Interface package for the Collaborative Robotics Toolkit (CRTK)
+naming convention used by the JHU cisst-SAW stack: OperatingState,
+StringStamped, CartesianImpedance*, TriggerOperatingState,
+QueryForwardKinematics, QueryInverseKinematics.  Required by
+@code{cisst_ros2_crtk} and, transitively, the sawSensablePhantom
+ROS 2 bridge."))
+
+(define-public ros-cisst-msgs-jazzy
+  (make-ros2-rosidl-interface-package
+   #:distro jazzy-distro
+   #:ros-name "cisst_msgs"
+   #:version "2.1.0"
+   #:repo "https://github.com/jhu-cisst/ros2_cisst_msgs"
+   #:commit "2addbab1afc3c998b95435baa16c6363f4b2e5ab"
+   #:hash (base32 "14spwl982bc7r2lbxdcxlx2lynwvx6ja0wnjn8simfhz3296gh2v")
+   #:message-deps (list ros-rosidl-default-generators-jazzy
+                        ros-rosidl-default-runtime-jazzy
+                        ros-builtin-interfaces-jazzy
+                        ros-rclcpp-jazzy
+                        ros-std-msgs-jazzy
+                        ros-sensor-msgs-jazzy
+                        ros-geometry-msgs-jazzy)
+   #:home-page "https://github.com/jhu-cisst/ros2_cisst_msgs"
+   #:synopsis "JHU cisst-specific ROS 2 message definitions"
+   #:description
+   "Interface package for cisst-specific ROS 2 messages: BoolStamped,
+DoubleVec, IntervalStatistics and a ConvertFloat64Array service.
+Consumed by @code{cisst_ros2_bridge} to translate cisst component
+state onto standard ROS 2 topics."))
+
 (define-public ros-sensable-omni-model-jazzy
   (make-ros2-ament-python-package
    #:distro jazzy-distro

--- a/systole/systole/packages/ros2/jazzy.scm
+++ b/systole/systole/packages/ros2/jazzy.scm
@@ -3741,6 +3741,8 @@ provided by guix-systole).")
         ;; utilities land in the union's bin/.
         (@ (systole packages openhaptics) openhaptics-sdk)
         (@ (systole packages openhaptics) touch-driver)
+        ;; saw-sensable-phantom (core) for its share/ JSON configs.
+        (@ (systole packages cisst) saw-sensable-phantom)
         ;; Slicer + all loadable/scripted modules + SlicerROS2.
         (@ (systole packages slicer) slicer-all-5.8)
         (@ (systole packages slicer-ros2) slicer-ros2-module-jazzy)))
@@ -3767,6 +3769,45 @@ provided by guix-systole).")
                        (inputs (map cdr %build-inputs)))
                    (union-build out inputs
                                 #:create-all-directories? #t)
+                   ;; Install the touch-demo launcher script.
+                   (let ((bin (string-append out "/bin/touch-demo")))
+                     (call-with-output-file bin
+                       (lambda (port)
+                         (display
+                          (string-append
+                           "#!/bin/bash\n"
+                           "# SlicerROS2 + 3D Systems Touch demo launcher.\n"
+                           "# Usage: guix shell ros-jazzy-touch -- touch-demo\n"
+                           "set -e\n"
+                           "export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp\n"
+                           "export CYCLONEDDS_URI='<CycloneDDS><Domain><General>"
+                           "<Interfaces><NetworkInterface name=\"lo\"/></Interfaces>"
+                           "</General><Discovery><ParticipantIndex>auto</ParticipantIndex>"
+                           "</Discovery></Domain></CycloneDDS>'\n"
+                           "P=${GUIX_ENVIRONMENT:-$(dirname $(dirname $(which ros2)))}\n"
+                           "JSON=$P/share/sawSensablePhantom/sawSensablePhantomDefaultDevice.json\n"
+                           "URDF=$P/share/sensable_omni_model/omni.urdf\n"
+                           "cleanup() { kill $SP $RSP $JSP 2>/dev/null; }\n"
+                           "trap cleanup EXIT\n"
+                           "echo '=== Touch node ==='\n"
+                           "ros2 run sensable_phantom sensable_phantom -j $JSON \"$@\" &\n"
+                           "SP=$!; sleep 8\n"
+                           "echo '=== robot_state_publisher ==='\n"
+                           "ros2 run robot_state_publisher robot_state_publisher "
+                           "--ros-args -p robot_description:=\"$(cat $URDF)\" &\n"
+                           "RSP=$!\n"
+                           "echo '=== joint_state_publisher ==='\n"
+                           "$P/bin/joint_state_publisher "
+                           "--ros-args -p \"source_list:=['/arm/measured_js']\" &\n"
+                           "JSP=$!; sleep 3\n"
+                           "echo '=== Slicer + ROS2 ==='\n"
+                           "Slicer --additional-module-paths "
+                           "$P/lib/Slicer-5.8/qt-loadable-modules "
+                           "$P/lib/Slicer-5.8/qt-scripted-modules &\n"
+                           "echo 'All started. Ctrl+C to stop.'\n"
+                           "wait\n")
+                          port)))
+                     (chmod bin #o755))
                    #t)))))
     (inputs
      (let ((direct %ros-jazzy-touch-packages))

--- a/systole/systole/packages/ros2/jazzy.scm
+++ b/systole/systole/packages/ros2/jazzy.scm
@@ -50,7 +50,8 @@
   #:use-module (gnu packages xml)          ; tinyxml2
   #:use-module (systole packages ros2)
   #:use-module (systole packages ros2-helpers) ; urdfdom, urdfdom-headers, console-bridge
-  #:use-module (systole packages cisst)         ; cisst, cisst-netlib (Touch demo)
+  #:use-module (systole packages cisst)         ; cisst, cisst-netlib, saw-* (Touch demo)
+  #:use-module (gnu packages qt)                ; qtbase-5 for the saw-*-ros wrappers
   #:use-module (srfi srfi-1)               ; delete-duplicates, append-map
   #:use-module (ice-9 match)               ; match-lambda
   #:export (jazzy-distro))
@@ -3174,12 +3175,14 @@ Sensable Phantom driver into @code{robot_state_publisher}."))
 ;; and sawSensablePhantom/ros actually use (and provides the
 ;; cisst_ral ROS 1/2 abstraction they require).
 ;;
-;; Pinned to tag 3.0.0 — introduces the cisst_ral abstraction required
-;; by the saw-components ROS 2 wrappers, without the 4.0.0 additions
-;; (CartesianState, servo_cs) that depend on an unreleased crtk_msgs.
-(define %cisst-ros-commit "5b3884b6f8ab0129ce0277e64cdc2346be9f00e1")
+;; Pinned to post-3.0.0 commit f6184aa — introduces the
+;; required_interface_name_for helper and the 6-argument
+;; bridge_interface_provided overload needed by saw_controllers_ros,
+;; but stops before 4.0.0's CartesianState/servo_cs additions which
+;; depend on an unreleased crtk_msgs with the new message type.
+(define %cisst-ros-commit "f6184aa310f230e2853ef252a3b52a5bca81a09e")
 (define %cisst-ros-hash
-  (base32 "02gpn8nh64gg98l0zw2zny54zf7jkynvlrzszyql67s26vpfzz3y"))
+  (base32 "105n9iqlark1yj0smjdffshxgac57qagi3ycww822vn86i72qi0d"))
 
 (define-public ros-crtk-msgs-jazzy
   (make-ros2-rosidl-interface-package
@@ -3314,6 +3317,104 @@ topics/services."))
 an RViz config for the 3D Systems Touch haptic device (formerly the
 Sensable Phantom Omni).  Consumed by @code{robot_state_publisher} when
 running Laura Connolly's SlicerROS2 Touch teleoperation demo."))
+
+(define-public ros-saw-controllers-ros-jazzy
+  (make-ros2-ament-cmake-package
+   #:distro jazzy-distro
+   #:ros-name "saw_controllers_ros"
+   #:version "2.3.0"
+   #:repo "https://github.com/jhu-saw/sawControllers"
+   #:commit "cc8870e20ef0954745a83cbc4eda7d167e3bda9a"
+   #:hash (base32 "0ih28k1b09hnqn4crk0ffpk6rrjxcnnld0y8xcsxyfk0vijnly3n")
+   #:module-subdir "ros"
+   #:extra-inputs (list cisst cisst-netlib saw-keyboard saw-controllers
+                        qtbase-5 qtxmlpatterns-5)
+   #:extra-configure-flags
+   #~(list (string-append "-Dcisst_DIR="
+                          #$cisst
+                          "/share/cisst-1.4/cmake")
+           (string-append "-DsawControllers_DIR="
+                          #$saw-controllers
+                          "/share/sawControllers")
+           (string-append "-DsawKeyboard_DIR="
+                          #$saw-keyboard
+                          "/share/sawKeyboard"))
+   #:propagated-inputs (list ros-ament-cmake-jazzy
+                             ros-cisst-ros-bridge-jazzy
+                             ros-cisst-ros-crtk-jazzy
+                             ros-crtk-msgs-jazzy
+                             ros-rclcpp-jazzy)
+   #:home-page "https://github.com/jhu-saw/sawControllers"
+   #:synopsis "ROS 2 bridge for cisst/SAW controllers"
+   #:description
+   "@code{saw_controllers_ros} exposes the JHU sawControllers PID /
+gravity-compensation / teleop components as ROS 2 CRTK-bridged nodes.
+Sub-package of jhu-saw/sawControllers built from the @file{ros/}
+subdirectory against our saw-controllers core package."))
+
+(define-public ros-sensable-phantom-jazzy
+  (make-ros2-ament-cmake-package
+   #:distro jazzy-distro
+   #:ros-name "sensable_phantom"
+   #:version "1.1.0"
+   #:repo "https://github.com/jhu-saw/sawSensablePhantom"
+   #:commit "64c8b05ec2263a93a1ebd1a2bd508c2c46d024a9"
+   #:hash (base32 "1a32y6qdsrpyvq9i2v0w5kw1xbngbi4nkm4rxvn83kaddwy4jm6b")
+   #:module-subdir "ros"
+   #:extra-inputs (list cisst cisst-netlib
+                        saw-keyboard saw-controllers saw-sensable-phantom
+                        qtbase-5 qtxmlpatterns-5
+                        ;; libHD; the sensable_phantom executable
+                        ;; links against it directly, not just through
+                        ;; libsawSensablePhantom.so's NEEDED.
+                        (@ (systole packages openhaptics) openhaptics-sdk)
+                        ;; libPhantomIOLib42.so — libHD's DT_NEEDED
+                        ;; that's dlopen'd at runtime, but the final
+                        ;; executable link requires its symbols
+                        ;; (get_phantom_rate, get_status_light, ...).
+                        (@ (systole packages openhaptics) touch-driver))
+   #:extra-configure-flags
+   #~(list (string-append "-Dcisst_DIR="
+                          #$cisst
+                          "/share/cisst-1.4/cmake")
+           (string-append "-DsawSensablePhantom_DIR="
+                          #$saw-sensable-phantom
+                          "/share/sawSensablePhantom")
+           (string-append "-DsawControllers_DIR="
+                          #$saw-controllers
+                          "/share/sawControllers")
+           (string-append "-DsawKeyboard_DIR="
+                          #$saw-keyboard
+                          "/share/sawKeyboard")
+           ;; libHD DT_NEEDED's libPhantomIOLib42.so (from touch-driver),
+           ;; which is only dlopen'd at runtime.  Tell ld to ignore
+           ;; unresolved symbols from shared libs at executable link.
+           "-DCMAKE_EXE_LINKER_FLAGS=-Wl,--unresolved-symbols=ignore-in-shared-libs")
+   #:propagated-inputs (list ros-ament-cmake-jazzy
+                             ros-cisst-ros-bridge-jazzy
+                             ros-cisst-ros-crtk-jazzy
+                             ros-crtk-msgs-jazzy
+                             ros-rclcpp-jazzy
+                             ros-xacro-jazzy
+                             ros-joint-state-publisher-jazzy
+                             ros-robot-state-publisher-jazzy
+                             ros-sensable-omni-model-jazzy)
+   #:home-page "https://github.com/jhu-saw/sawSensablePhantom"
+   #:synopsis "3D Systems Touch haptic device ROS 2 node (sensable_phantom)"
+   #:description
+   "@code{sensable_phantom} is the JHU cisst-SAW ROS 2 executable that
+drives the 3D Systems Touch haptic device over OpenHaptics and
+publishes the device state on CRTK topics (@code{/arm/measured_js},
+@code{/arm/measured_cp}, @code{/arm/measured_cf}, @code{/arm/operating_state})
+while subscribing to @code{/arm/servo_cf} for haptic feedback.  Ships
+the @file{sensable_phantom_rviz.launch.py} launch file used by Laura
+Connolly's SlicerROS2 Touch teleoperation demo.
+
+At runtime this package pulls in @code{touch-driver} and
+@code{openhaptics-sdk} transitively through @code{saw-sensable-phantom},
+so installing @code{ros-sensable-phantom-jazzy} into a profile gives
+a complete Touch ROS 2 node ready to @code{ros2 run sensable_phantom
+sensable_phantom}."))
 
 ;;;
 ;;; Aggregation meta-package.

--- a/systole/systole/packages/ros2/jazzy.scm
+++ b/systole/systole/packages/ros2/jazzy.scm
@@ -3740,7 +3740,10 @@ provided by guix-systole).")
         ;; Touch_Setup, Touch_Diagnostic, and ListUSBHapticDevices
         ;; utilities land in the union's bin/.
         (@ (systole packages openhaptics) openhaptics-sdk)
-        (@ (systole packages openhaptics) touch-driver)))
+        (@ (systole packages openhaptics) touch-driver)
+        ;; Slicer + all loadable/scripted modules + SlicerROS2.
+        (@ (systole packages slicer) slicer-all-5.8)
+        (@ (systole packages slicer-ros2) slicer-ros2-module-jazzy)))
 
 (define-public ros-jazzy-touch
   (package

--- a/systole/systole/packages/slicer-ros2.scm
+++ b/systole/systole/packages/slicer-ros2.scm
@@ -38,8 +38,10 @@
   #:use-module (guix packages)
   #:use-module (guix utils)
   #:use-module (gnu packages python)
+  #:use-module (gnu packages qt)
   #:use-module (systole packages slicer)
-  #:use-module (systole packages ros2 jazzy))
+  #:use-module (systole packages ros2 jazzy)
+  #:use-module (srfi srfi-1))
 
 ;;;
 ;;; SlicerROS2 loadable module (jazzy).
@@ -98,7 +100,18 @@
                 ;; CMAKE_INSTALL_PREFIX.  Strip the leading slash.
                 (substitute* "CMakeLists.txt"
                   (("DESTINATION /\\$\\{SlicerROS2_AMENT_INSTALL_PREFIX\\}")
-                   "DESTINATION ${SlicerROS2_AMENT_INSTALL_PREFIX}"))))
+                   "DESTINATION ${SlicerROS2_AMENT_INSTALL_PREFIX}"))
+                ;; (3) Logic/vtkSlicerROS2Logic.cxx includes
+                ;; <qSlicerCoreApplication.h> and references symbols from
+                ;; qSlicerBaseQTCore + ctkVTKWidgets that aren't in the
+                ;; Logic lib's TARGET_LIBRARIES.  Add them so the link
+                ;; resolves.
+                (substitute* "Logic/CMakeLists.txt"
+                  (("vtkSlicer\\$\\{MODULE_NAME\\}ModuleMRML")
+                   (string-append
+                    "vtkSlicer${MODULE_NAME}ModuleMRML\n"
+                    "  qSlicerBaseQTCore\n"
+                    "  CTKVisualizationVTKWidgets")))))
             (add-after 'unpack 'make-generator-executable
               (lambda _
                 ;; Upstream runs ROS2_to_vtkObjects.py at cmake time via
@@ -121,39 +134,63 @@
                 (setenv "CXXFLAGS"
                         (string-append
                          (or (getenv "CXXFLAGS") "")
-                         " -Wno-error")))))))
+                         " -Wno-error"))))
+            (add-after 'patch-install-layout 'add-qt5-uitools
+              (lambda* (#:key inputs #:allow-other-keys)
+                ;; qSlicerROS2ModuleWidget.cxx includes <QUiLoader>.
+                ;; Upstream's CMakeLists.txt doesn't request the Qt5
+                ;; UiTools component, so inject find_package() + an
+                ;; include_directories() call at the top.
+                (let ((qttools (assoc-ref inputs "qttools")))
+                  ;; Inject after the main find_package(Slicer REQUIRED)
+                  ;; (which runs project() and enables CXX), so the Qt5
+                  ;; UiTools find_package has an enabled CXX language.
+                  (substitute* "CMakeLists.txt"
+                    (("find_package\\(Slicer REQUIRED\\)")
+                     (string-append
+                      "find_package(Slicer REQUIRED)\n"
+                      "find_package(Qt5 REQUIRED COMPONENTS UiTools)\n"
+                      "include_directories(SYSTEM \""
+                      qttools "/include/qt5\" \""
+                      qttools "/include/qt5/QtUiTools\")\n"
+                      "link_libraries(Qt5::UiTools)")))))))))
       (native-inputs (list python))
+      ;; UseSlicer.cmake transitively requires all of slicer-5.8's build-time
+      ;; libraries (Qt5, VTK, ITK, PNG, EXPAT, HDF5, ...) at configure time,
+      ;; not just slicer-5.8 itself.  We start from slicer-5.8's own input
+      ;; list (same pattern as make-slicer-loadable-module) and prepend
+      ;; slicer-5.8 + the ROS 2 deps upstream SlicerROS2 declares.
       (inputs
-       ;; Slicer + all ROS 2 packages the upstream CMakeLists lists in
-       ;; SlicerROS2_ROS_DEPENDENCIES, minus cisst_msgs (gated on
-       ;; USE_CISST_MSGS, we build with it off).
-       (list slicer-5.8
-             ;; rosidl pipeline bits the code generator needs
-             ros-rclcpp-jazzy
-             ros-rclcpp-action-jazzy
-             ;; URDF / KDL
-             ros-kdl-parser-jazzy
-             ros-urdf-jazzy
-             ;; tf2 stack
-             ros-tf2-jazzy
-             ros-tf2-ros-jazzy
-             ros-tf2-msgs-jazzy
-             ;; turtlesim (required by find_package loop)
-             ros-turtlesim-jazzy
-             ;; interface families
-             ros-builtin-interfaces-jazzy
-             ros-std-msgs-jazzy
-             ros-std-srvs-jazzy
-             ros-geometry-msgs-jazzy
-             ros-sensor-msgs-jazzy
-             ros-shape-msgs-jazzy
-             ros-trajectory-msgs-jazzy
-             ros-object-recognition-msgs-jazzy
-             ros-octomap-msgs-jazzy
-             ros-moveit-msgs-jazzy
-             ros-rosbag2-interfaces-jazzy
-             ;; Python 3 for the build-time code generator
-             python))
+       (fold (lambda (pkg acc)
+               (modify-inputs acc (prepend pkg)))
+             (modify-inputs (package-inputs slicer-5.8)
+               (prepend slicer-5.8))
+             (list
+              ;; ROS 2 packages from upstream SlicerROS2_ROS_DEPENDENCIES
+              ;; (minus cisst_msgs, gated on USE_CISST_MSGS).
+              ros-rclcpp-jazzy
+              ros-rclcpp-action-jazzy
+              ros-kdl-parser-jazzy
+              ros-urdf-jazzy
+              ros-tf2-jazzy
+              ros-tf2-ros-jazzy
+              ros-tf2-msgs-jazzy
+              ros-turtlesim-jazzy
+              ros-builtin-interfaces-jazzy
+              ros-std-msgs-jazzy
+              ros-std-srvs-jazzy
+              ros-geometry-msgs-jazzy
+              ros-sensor-msgs-jazzy
+              ros-shape-msgs-jazzy
+              ros-trajectory-msgs-jazzy
+              ros-object-recognition-msgs-jazzy
+              ros-octomap-msgs-jazzy
+              ros-moveit-msgs-jazzy
+              ros-rosbag2-interfaces-jazzy
+              ;; Qt5 UiTools for QUiLoader used in the widget.
+              qttools
+              ;; Python 3 for the build-time code generator
+              python)))
       ;; Propagate slicer-5.8 so `guix install slicer-ros2-module-jazzy'
       ;; brings a usable Slicer alongside it; also propagate ros-jazzy
       ;; components whose .so files are dlopen'd by the module at

--- a/systole/systole/packages/slicer-ros2.scm
+++ b/systole/systole/packages/slicer-ros2.scm
@@ -1,0 +1,181 @@
+;;
+;; Copyright @ 2026 Oslo University Hospital
+;;
+;; This file is part of SystoleOS.
+;;
+;; SystoleOS is free software: you can redistribute it and/or modify it under the
+;; terms of the GNU General Public License as published by the Free Software
+;; Foundation, either version 3 of the License, or (at your option) any later version.
+;;
+;; SystoleOS is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+;; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+;; PURPOSE. See the GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License along
+;; with SystoleOS. If not, see <https://www.gnu.org/licenses/>.
+;;
+
+;;; Commentary:
+;;;
+;;; SlicerROS2 — a 3D Slicer loadable module that bridges Slicer's MRML
+;;; scene graph to the ROS 2 middleware, maintained at
+;;; https://github.com/rosmed/slicer_ros2_module.
+;;;
+;;; Upstream is a hybrid ament_cmake + Slicer-loadable-module project:
+;;; it calls `find_package(Slicer)' + `slicerMacroBuildLoadableModule'
+;;; AND `find_package(ament_cmake)' + ROS 2 message/client-library
+;;; find_package()s in the same CMakeLists.txt.  We build it against
+;;; the @code{slicer-5.8} package from (systole packages slicer) and
+;;; the ROS 2 Jazzy components from (systole packages ros2 jazzy).
+;;;
+;;; Code:
+
+(define-module (systole packages slicer-ros2)
+  #:use-module ((guix licenses) #:prefix license:)
+  #:use-module (guix build-system cmake)
+  #:use-module (guix gexp)
+  #:use-module (guix git-download)
+  #:use-module (guix packages)
+  #:use-module (guix utils)
+  #:use-module (gnu packages python)
+  #:use-module (systole packages slicer)
+  #:use-module (systole packages ros2 jazzy))
+
+;;;
+;;; SlicerROS2 loadable module (jazzy).
+;;;
+
+(define-public slicer-ros2-module-jazzy
+  (let ((commit "e7bf7febb484aed329fc9ddacb59a3feca86f44d"))
+    (package
+      (name "slicer-ros2-module-jazzy")
+      (version (git-version "0.0.0" "0" commit))
+      (source
+       (origin
+         (method git-fetch)
+         (uri (git-reference
+               (url "https://github.com/rosmed/slicer_ros2_module")
+               (commit commit)))
+         (file-name (git-file-name name commit))
+         (sha256
+          (base32 "1dcjwah2gd6qy7214hb8dj5lx7d4j02fxkb68825v9jgcffjc11n"))))
+      (build-system cmake-build-system)
+      (arguments
+       (list
+        #:tests? #f
+        #:validate-runpath? #f
+        #:out-of-source? #t
+        #:configure-flags
+        #~(list "-DCMAKE_BUILD_TYPE=Release"
+                "-DBUILD_TESTING=OFF"
+                "-DUSE_CISST_MSGS=OFF"
+                ;; Install everything under $out, not under Slicer_DIR.
+                (string-append "-DCMAKE_INSTALL_PREFIX=" #$output)
+                (string-append "-DSlicerROS2_AMENT_INSTALL_PREFIX=" #$output)
+                ;; Slicer modules must install into a consistent layout
+                ;; so SLICER_ADDITIONAL_MODULE_PATHS can find them.
+                (string-append "-DSlicer_INSTALL_QTLOADABLEMODULES_LIB_DIR="
+                               "lib/Slicer-5.8/qt-loadable-modules")
+                (string-append "-DSlicer_INSTALL_QTLOADABLEMODULES_SHARE_DIR="
+                               "share/Slicer-5.8/qt-loadable-modules")
+                ;; Point cmake directly at Slicer's config dir.
+                (string-append "-DSlicer_DIR="
+                               #$(this-package-input "slicer-5.8")
+                               "/lib/Slicer-5.8"))
+        #:phases
+        #~(modify-phases %standard-phases
+            (add-after 'unpack 'patch-install-layout
+              (lambda _
+                ;; (1) Upstream forces CMAKE_INSTALL_PREFIX to Slicer_DIR
+                ;; with FORCE, which in our case is an inside-the-store
+                ;; read-only path.  Drop the override so our
+                ;; -DCMAKE_INSTALL_PREFIX=$out sticks.
+                (substitute* "CMakeLists.txt"
+                  (("set\\(CMAKE_INSTALL_PREFIX \\$\\{Slicer_DIR\\}.*FORCE\\)")
+                   "# CMAKE_INSTALL_PREFIX override dropped by guix-systole"))
+                ;; (2) The local_setup.bash install has a leading slash on
+                ;; DESTINATION, making it an absolute path and ignoring
+                ;; CMAKE_INSTALL_PREFIX.  Strip the leading slash.
+                (substitute* "CMakeLists.txt"
+                  (("DESTINATION /\\$\\{SlicerROS2_AMENT_INSTALL_PREFIX\\}")
+                   "DESTINATION ${SlicerROS2_AMENT_INSTALL_PREFIX}"))))
+            (add-after 'unpack 'make-generator-executable
+              (lambda _
+                ;; Upstream runs ROS2_to_vtkObjects.py at cmake time via
+                ;; execute_process(COMMAND <script> ...).  It's shipped
+                ;; with a #!/usr/bin/python3 shebang — patch-shebangs
+                ;; fixes the interpreter, but we also need the +x bit.
+                (chmod "MRML/CodeGeneration/ROS2_to_vtkObjects.py" #o755)))
+            ;; Slicer modules build a family of co-located .so files that
+            ;; dlopen each other; add $ORIGIN to every intermediate dir so
+            ;; they resolve from the install tree.  Also let binaries
+            ;; nested one level deeper resolve siblings.
+            (add-before 'configure 'set-install-rpath
+              (lambda _
+                (setenv "CMAKE_INSTALL_RPATH"
+                        "$ORIGIN:$ORIGIN/..:$ORIGIN/../../..")))
+            ;; Slicer's build system prepends -Werror=... to some flags;
+            ;; don't escalate those here.
+            (add-before 'configure 'relax-warnings
+              (lambda _
+                (setenv "CXXFLAGS"
+                        (string-append
+                         (or (getenv "CXXFLAGS") "")
+                         " -Wno-error")))))))
+      (native-inputs (list python))
+      (inputs
+       ;; Slicer + all ROS 2 packages the upstream CMakeLists lists in
+       ;; SlicerROS2_ROS_DEPENDENCIES, minus cisst_msgs (gated on
+       ;; USE_CISST_MSGS, we build with it off).
+       (list slicer-5.8
+             ;; rosidl pipeline bits the code generator needs
+             ros-rclcpp-jazzy
+             ros-rclcpp-action-jazzy
+             ;; URDF / KDL
+             ros-kdl-parser-jazzy
+             ros-urdf-jazzy
+             ;; tf2 stack
+             ros-tf2-jazzy
+             ros-tf2-ros-jazzy
+             ros-tf2-msgs-jazzy
+             ;; turtlesim (required by find_package loop)
+             ros-turtlesim-jazzy
+             ;; interface families
+             ros-builtin-interfaces-jazzy
+             ros-std-msgs-jazzy
+             ros-std-srvs-jazzy
+             ros-geometry-msgs-jazzy
+             ros-sensor-msgs-jazzy
+             ros-shape-msgs-jazzy
+             ros-trajectory-msgs-jazzy
+             ros-object-recognition-msgs-jazzy
+             ros-octomap-msgs-jazzy
+             ros-moveit-msgs-jazzy
+             ros-rosbag2-interfaces-jazzy
+             ;; Python 3 for the build-time code generator
+             python))
+      ;; Propagate slicer-5.8 so `guix install slicer-ros2-module-jazzy'
+      ;; brings a usable Slicer alongside it; also propagate ros-jazzy
+      ;; components whose .so files are dlopen'd by the module at
+      ;; runtime for message (de)serialization.
+      (propagated-inputs
+       (list slicer-5.8
+             ros-rclcpp-jazzy
+             ros-rmw-implementation-jazzy
+             ros-rmw-cyclonedds-cpp-jazzy
+             ros-tf2-jazzy
+             ros-tf2-ros-jazzy
+             ros-kdl-parser-jazzy
+             ros-urdf-jazzy))
+      (home-page "https://github.com/rosmed/slicer_ros2_module")
+      (synopsis "3D Slicer loadable module bridging MRML to ROS 2")
+      (description
+       "@code{slicer_ros2_module} is a 3D Slicer loadable module that
+exposes ROS 2 nodes, publishers, subscribers, service clients,
+parameters, and a @code{tf2} buffer inside Slicer's MRML scene graph.
+It is built against the @code{slicer-5.8} package and the ROS 2
+Jazzy distribution provided by the @code{systole} channel.
+
+Set @env{RMW_IMPLEMENTATION=rmw_cyclonedds_cpp} in the profile that
+installs this package to match the bundled RMW.")
+      (license license:expat))))

--- a/tests/packages/test-modules-load.sh
+++ b/tests/packages/test-modules-load.sh
@@ -22,6 +22,7 @@ MODULES=(
     "(systole packages ros2)"
     "(systole packages ros2-helpers)"
     "(systole packages ros2 jazzy)"
+    "(systole packages slicer-ros2)"
 )
 
 FAILED=0


### PR DESCRIPTION
## Summary

- Package the full JHU cisst/SAW stack for driving the 3D Systems Touch haptic device via ROS 2 Jazzy
- Package the SlicerROS2 loadable module (rosmed/slicer_ros2_module) against slicer-5.8 + ros-jazzy
- Ship a one-command reproducible demo: `guix shell ros-jazzy-touch -- touch-demo`

## New packages (20 commits)

**Proprietary (auto-fetched from 3D Systems' public S3):**
- `openhaptics-sdk` — OpenHaptics 3.4 Developer Edition (libHD, libHL, headers)
- `touch-driver` — Touch USB driver (libPhantomIOLib42, Touch_Setup, udev rule)

**JHU cisst framework:**
- `cisst-netlib` — F2C-translated LAPACK/BLAS (offline clapack)
- `cisst` — 12 shared libs (Qt5 + cisstRobot enabled)
- `saw-keyboard`, `saw-controllers`, `saw-sensable-phantom`

**ROS 2 Jazzy packages:**
- `ros-xacro-jazzy`, `ros-joint-state-publisher-jazzy`, `ros-sensable-omni-model-jazzy`
- `ros-crtk-msgs-jazzy`, `ros-cisst-msgs-jazzy` (from jhu-cisst/cisst-ros monorepo)
- `ros-cisst-ros-bridge-jazzy`, `ros-cisst-ros-crtk-jazzy` (cisst_ral abstraction)
- `ros-saw-controllers-ros-jazzy`, `ros-sensable-phantom-jazzy` (the Touch ROS 2 node)

**SlicerROS2:**
- `slicer-ros2-module-jazzy` — loadable module bridging MRML to ROS 2

**Meta-package:**
- `ros-jazzy-touch` — union of everything (Slicer + all modules + ROS2 + Touch stack + launcher script)

## Usage

```bash
guix shell ros-jazzy-touch -- touch-demo
```

Starts sensable_phantom + robot_state_publisher + joint_state_publisher + Slicer with all modules and ROS2. Ctrl+C stops everything.

## Test plan

- [x] All packages build (`guix build -L systole <pkg>`)
- [x] `sensable_phantom` initializes Touch device, publishes 29 CRTK topics
- [x] `ros2 topic echo /arm/measured_cp` shows real-time pose updates
- [x] Slicer loads ROS2 module, discovers robot via `/robot_description`
- [x] URDF transforms update in Slicer when moving the Touch stylus
- [x] `./scripts/run-tests.sh` passes