### PR TITLE
[ENH][packages/slicer] Add pip local install support

### DIFF
--- a/systole/systole/packages/patches/slicer/0079-ENH-Add-GUIX_ENVIRONMENT-module-path-to-LD_LIBRARY_P.patch
+++ b/systole/systole/packages/patches/slicer/0079-ENH-Add-GUIX_ENVIRONMENT-module-path-to-LD_LIBRARY_P.patch
@@ -1,0 +1,61 @@
+From 5774424775b4d022ad0d421d329a44cf7f3e4942 Mon Sep 17 00:00:00 2001
+From: Rafael Palomar <rafael.palomar@ous-research.no>
+Date: Fri, 6 Mar 2026 12:22:41 +0100
+Subject: [PATCH] ENH: Add GUIX_ENVIRONMENT module path to LD_LIBRARY_PATH and
+ set PIP_USER=1 at startup
+
+---
+ Base/QTCore/qSlicerCoreApplication.cxx | 30 ++++++++++++++++++++++++++
+ 1 file changed, 30 insertions(+)
+
+diff --git a/Base/QTCore/qSlicerCoreApplication.cxx b/Base/QTCore/qSlicerCoreApplication.cxx
+index cad384a165..ff89453936 100644
+--- a/Base/QTCore/qSlicerCoreApplication.cxx
++++ b/Base/QTCore/qSlicerCoreApplication.cxx
+@@ -381,6 +381,31 @@ void qSlicerCoreApplicationPrivate::init()
+     }
+   }
+ 
++  // When running inside a Guix shell, also add the merged profile's
++  // qt-loadable-modules directory so that built-in module .so files are
++  // found even if SLICER_ADDITIONAL_MODULE_PATHS covers only extension paths.
++  {
++  QByteArray guixEnv = qgetenv("GUIX_ENVIRONMENT");
++  if (!guixEnv.isEmpty())
++    {
++    QString guixMods = QString::fromLocal8Bit(guixEnv)
++      + QStringLiteral("/lib/Slicer-")
++      + QString::number(Slicer_VERSION_MAJOR)
++      + QStringLiteral(".") + QString::number(Slicer_VERSION_MINOR)
++      + QStringLiteral("/qt-loadable-modules");
++    if (QDir(guixMods).exists())
++      {
++      QStringList newPaths;
++      newPaths.prepend(guixMods);
++      QString existing = this->Environment.value("LD_LIBRARY_PATH");
++      if (!existing.isEmpty())
++        newPaths << existing.split(QLatin1Char(':'));
++      newPaths.removeDuplicates();
++      q->setEnvironmentVariable("LD_LIBRARY_PATH", newPaths.join(QLatin1Char(':')));
++      }
++    }
++  }
++
+   // Build PYTHONPATH for the Guix profile layout:
+   //   1. CTK_LIBRARY_DIR     — CTKWidgetsPythonQt*.so and other CTK PythonQt
+   //                            extension modules (installed to lib/, no subdir).
+@@ -411,6 +436,11 @@ void qSlicerCoreApplicationPrivate::init()
+     }
+   }
+ 
++  // Direct pip to install to ~/.local so slicer.util.pip_install works
++  // from an immutable Guix store.  Equivalent to passing --user to pip.
++  if (qgetenv("PIP_USER").isEmpty())
++    q->setEnvironmentVariable("PIP_USER", "1");
++
+ #ifdef Slicer_USE_PYTHONQT_WITH_OPENSSL
+   if (!QSslSocket::supportsSsl())
+   {
+-- 
+2.52.0
+

--- a/systole/systole/packages/slicer.scm
+++ b/systole/systole/packages/slicer.scm
@@ -196,7 +196,9 @@ development tools, code search, and documentation generation.")
                  "0072-COMP-Register-Slicer-qMRML-designer-plugins-dir-so-Q.patch"
                  "0073-COMP-Export-Slicer_BUILD_QT_DESIGNER_PLUGINS-in-inst.patch"
                  "0074-COMP-Fix-designer-plugin-build-dir-and-install-path-.patch"
-                 "0075-COMP-Install-Slicer-VTK-hierarchy-files-and-expose-p.patch"))))
+                 "0075-COMP-Install-Slicer-VTK-hierarchy-files-and-expose-p.patch"
+                 "0076-ENH-Redirect-pip_install-to-user-home-and-update-sys.patch"
+                 "0079-ENH-Add-GUIX_ENVIRONMENT-module-path-to-LD_LIBRARY_P.patch"))))
 
     (build-system cmake-build-system)
     (arguments


### PR DESCRIPTION
Add two patches enabling Python package installation to ~/.local from within Slicer running in a Guix environment:

- 0076: Redirect slicer.util.pip_install to install with --user flag and update sys.path so newly installed packages are importable immediately.

- 0079: At C++ init time, set PIP_USER=1 so any pip invocation defaults to user-mode install. Also prepend the Guix profile's qt-loadable-modules dir to LD_LIBRARY_PATH when GUIX_ENVIRONMENT is set, ensuring built-in module .so files are found even when SLICER_ADDITIONAL_MODULE_PATHS only covers extension paths.